### PR TITLE
Update Thresholding

### DIFF
--- a/anomaly_detector/anomaly_detector.py
+++ b/anomaly_detector/anomaly_detector.py
@@ -136,10 +136,11 @@ class AnomalyDetector():
     def infer(self):
         """Perform inference on trained models."""
         meta_data = self.model.get_metadata()
-        maxx = meta_data[2]
-        stdd = meta_data[1]
 
-        _LOGGER.info("Maxx: %f, stdd: %f" % (maxx, stdd))
+        stdd = meta_data[1]
+        mean = meta_data[0]
+
+        _LOGGER.info("Mean: %f, stdd: %f" % (mean, stdd))
 
         _LOGGER.info("Models loaded, running %d infer loops" % self.config.INFER_LOOPS)
 
@@ -172,11 +173,11 @@ class AnomalyDetector():
 
             _LOGGER.info("Max anomaly score: %f" % max(dist))
             for i in range(len(data)):
-                _LOGGER.debug("Updating entry %d - dist: %f; maxx: %f" % (i, dist[i], maxx))
+                _LOGGER.debug("Updating entry %d - dist: %f; mean: %f" % (i, dist[i], mean))
                 s = json_logs[i]    # This needs to be more general, only works for ES incoming logs right now.
                 s['anomaly_score'] = dist[i]
 
-                if dist[i] > (self.config.INFER_ANOMALY_THRESHOLD * maxx):
+                if dist[i] > (self.config.INFER_ANOMALY_THRESHOLD * stdd + mean):
                     s['anomaly'] = 1
                     _LOGGER.warn("Anomaly found (score: %f): %s" % (dist[i], s['message']))
                 else:

--- a/anomaly_detector/config.py
+++ b/anomaly_detector/config.py
@@ -57,7 +57,7 @@ class Configuration():
     TRAIN_UPDATE_MODEL = False
 
     # Threshold used to decide whether an entry is an anomaly
-    INFER_ANOMALY_THRESHOLD = 1.1
+    INFER_ANOMALY_THRESHOLD = 3.1
     # Number of seconds specifying how far in the past to go to load log entries for inference TODO: move to es storage backend
     INFER_TIME_SPAN = 60
     # Number of inferences before retraining the models

--- a/openshift/log-anomaly-detector.app.yaml
+++ b/openshift/log-anomaly-detector.app.yaml
@@ -188,7 +188,7 @@ parameters:
     value: "20"
   - name: INFER_ANOMALY_THRESHOLD
     descripton: "Threshold for marking a log entry an anomaly"  
-    value: "1.3"
+    value: "3.1"
 #ES Storage Backend
   - name: ES_ENDPOINT
     descripton: "Elasticsearch endpoint to pull log data from for training"


### PR DESCRIPTION
To address issue #18 , I have updated the anomaly detector to use the standard deviation and mean in the training data to generate the threshold value for classifying anomalies, as opposed to the the maximum distance.  

Also updated the environment variable INFER_ANOMALY_THRESHOLD from 1.1 to 3.1 for both openshift and local config to generate a reasonable value for the new threshold calculation. 

related: #18