### PR TITLE
add windowing to w2v

### DIFF
--- a/anomaly_detector/anomaly_detector.py
+++ b/anomaly_detector/anomaly_detector.py
@@ -90,7 +90,7 @@ class AnomalyDetector():
         if not self.recreate_models and self.update_w2v_model:
             self.w2v_model.update(data)
         else:
-            self.w2v_model.create(data)
+            self.w2v_model.create(data, self.config.TRAIN_VECTOR_LENGTH, self.config.TRAIN_WINDOW)
 
         try:
             self.w2v_model.save(self.config.W2V_MODEL_PATH)

--- a/anomaly_detector/config.py
+++ b/anomaly_detector/config.py
@@ -56,6 +56,10 @@ class Configuration():
     TRAIN_ITERATIONS = 4500
     # If true, re-traing the models
     TRAIN_UPDATE_MODEL = False
+    # Set the window size for word2Vec training
+    TRAIN_WINDOW = 5
+    # Set the length of the encoded log vectors
+    TRAIN_VECTOR_LENGTH = 25
 
     # Threshold used to decide whether an entry is an anomaly
     INFER_ANOMALY_THRESHOLD = 3.1

--- a/anomaly_detector/model/w2v_model.py
+++ b/anomaly_detector/model/w2v_model.py
@@ -23,12 +23,12 @@ class W2VModel(BaseModel):
                 _LOGGER.warning("Skipping key %s as it does not exist in 'words'" % col)
         _LOGGER.info("Models Updated")
 
-    def create(self, words):
+    def create(self, words, vector_length, window_size):
         """Create new word2vec model."""
         self.model = {}
         for col in words.columns:
             if col in words:
-                self.model[col] = Word2Vec([list(words[col])], min_count=1, size=50)
+                self.model[col] = Word2Vec([list(words[col])], min_count=1, size=vector_length, window=window_size)
             else:
                 _LOGGER.warning("Skipping key %s as it does not exist in 'words'" % col)
 


### PR DESCRIPTION
This PR relates to issue #1. It includes a very small change to `model/w2v_model.py` method `create()` that adds a windowing limit for the co-occurrence of logs while training the initial word2vec model. This should create a better (more meaningful) vector representation for our logs. And some off-line testing leads me to believe that it should also produce some more consistent results as far as logs that are flagged as being anomalous. 

Note: in this PR the windowing limit has been set to 5. But this is a hyper parameter that can be tuned, if needed, at a later time.         