### PR TITLE
add validation data directory

### DIFF
--- a/anomaly_detector/config.py
+++ b/anomaly_detector/config.py
@@ -36,6 +36,10 @@ class Configuration():
 
     # One of the storage backends available in storage/ dir
     STORAGE_BACKEND = "local"
+    # Location of local data
+    LOCAL_DATA_FILE = os.environ['LOCAL_DATA_FILE']
+    # Name of local results data
+    LOCAL_RESULTS_FILE = os.environ['LOCAL_RESULTS_FILE']
     # A directory where trained models will be stored
     MODEL_DIR = "./models/"
     MODE_DIR_CALLABLE = check_or_create_model_dir

--- a/anomaly_detector/storage/local_storage.py
+++ b/anomaly_detector/storage/local_storage.py
@@ -81,9 +81,9 @@ class LSConfiguration(Configuration):
     """Configuration for local storage."""
 
     # Path to a file containing input data. If the value is '-' the input is expected on STDIN
-    LS_INPUT_PATH = ""
+    LS_INPUT_PATH = Configuration.LOCAL_DATA_FILE #"validation_data/verification_data.json"
     # Path to a file where the results will be stored. Results will be printed to STDOUT if empty
-    LS_OUTPUT_PATH = ""
+    LS_OUTPUT_PATH = Configuration.LOCAL_RESULTS_FILE
 
     def __init__(self):
         """Initialize configuration."""

--- a/validation_data/REAMDE.md
+++ b/validation_data/REAMDE.md
@@ -1,0 +1,61 @@
+
+# Validation Data
+
+The purpose of this code is to provide users a simple way to get access to data and run the app 
+locally for testing and verification.  
+
+#### The Data Set
+
+The script `generate_validation_data.py` collects **80,000** logs from the service of your choice hosted at your Elasticsearch endpoint in the index you define.  
+
+Of the 80,000 logs, the training set is unchanged at constitutes **80% of the dataset (64,000 logs)** and the test set makes up the remaining **20% (16,000 logs)**
+
+The test set was genereated by randomly selecting **10% of the training data (~1,600)** and replacing it with random character strings.
+
+The output files **verification_data_new.json** and **labels_new.pkl** are saved to the current directory
+
+
+#### How to download local test data
+
+Set the correct environment variables for your Elasticsearch endpoint, index and service you want to pull data from.
+
+````
+export LAD_ENDPOINT="<your endpoint>" 
+export LAD_INDEX="<your index>"
+export LAD_SERVICE="<your service>"
+````
+
+Run the script `generate_validation_data.py`
+
+````
+python generate_validation_data.py
+````
+If this ran correctly you should see the following output:
+
+````
+80000 logs and corresponding labels saved to disk as verification_data.json and labels.pkl
+```` 
+
+The verification_data.json and labels.pkl are now stored locally for testing with the anomaly detector using the default local backend.
+
+#### How to run a local test 
+
+Set the correct environment variables for your local data location and output file.
+
+````
+export LOCAL_DATA_FILE="validation_data/verification_data.json"
+export LOCAL_RESULTS_FILE="results.json"
+```` 
+
+From the root directory run `app.py`.
+
+````
+python app.py
+````
+
+This will kick of a training and inference loop, printing status and found anomlies to the terminal. 
+
+Since this is a static dataset meant for local validation and testing. You should `ctrl+c` out of the program after the first infrence loop as no additional data is being passed in.
+
+With the `results.json` and `labels.pkl` you can check the ability of the current anomaly detector (with current parameters) 
+to detect our generated anomalies of random character strings offline. Future iteration of this tool will include some additional validation capabilities.       

--- a/validation_data/generate_validation_data.py
+++ b/validation_data/generate_validation_data.py
@@ -1,0 +1,94 @@
+import json
+import numpy as np
+import random
+import pickle
+from elasticsearch2 import Elasticsearch
+import os
+
+ENDPOINT = os.environ["LAD_ENDPOINT"]
+INDEX = os.environ['LAD_INDEX']
+SERVICE = os.environ['LAD_SERVICE']
+
+DEFALULT_QUERY = {'query': {'match': {'service': SERVICE}},
+				  "filter": {"range": {"@timestamp": {"gte": "now-2s", "lte": "now"}}},
+				  'sort': {'@timestamp': {'order': 'desc'}},
+				  "size": 20  # size is more critical than "terminate_after" to limit query size!!!
+				  }
+
+
+def get_data_from_es(endpoint, index, service, num=20, time=2, query=DEFALULT_QUERY):
+	"""
+	This function pulls data from a user defined Elasticsearch endpoint, index and service.
+	It also allows the user to dictate the number entires pulled and the timeframe in seconds.
+	"""
+
+	es = Elasticsearch(endpoint, timeout=30)
+	query['size'] = num
+	query['filter']['range']['@timestamp']['gte'] = 'now-' + str(time) + 's'
+	query['query']['match']['service'] = service
+
+	return es.search(index, body=json.dumps(query), request_timeout=500)
+
+
+def create_anomlous_entires(string, entropy):
+	"""
+	This function takes a string and randomly replaces characters with random characters.
+	The parameter 'entropy' is a value between 0 and 1 that dictates what percent of the string is changed.
+	"""
+
+	string_length = len(string)
+
+	if entropy > 1:
+		raise ValueError("entropy should be a real valued number between 0 and 1")
+	for i in range(round(string_length * entropy)):
+		random_location = random.randint(0, string_length - 1)
+		string = list(string)
+		string[random_location] = chr(random.randint(65, 123))
+		string = "".join(string)
+
+	return string
+
+
+def main():
+	random.seed(42)
+	data = get_data_from_es(ENDPOINT, INDEX, SERVICE, num=800, time=6000000)
+	logs = data['hits']['hits']
+
+	eighty_percent = int(round(len(logs) * 0.80))
+	y = np.zeros(len(logs))
+	anomaly_degrees = [0, 1]
+	labels = [0, 1]
+
+	data = []
+	label = 0
+
+	for i in range(0, eighty_percent):
+		current_log = logs[i]['_source']
+		data.append({"message": current_log['message'].strip()})
+		y[i] = labels[label]
+
+	for i in range(eighty_percent, len(logs)):  # only the last 20% of the data will have anomlies.
+		current_log = logs[i]['_source']
+		gate = random.randint(1, 100)
+
+		if gate < 90:
+			pass
+		if gate >= 90:
+			label = 1
+
+		data.append({"message": create_anomlous_entires(current_log['message'].strip(), anomaly_degrees[label])})
+		y[i] = labels[label]
+		label = 0
+
+	print(len(data), "logs and corresponding labels saved to disk as verification_data.json and labels.pkl")
+
+	with open('verification_data.json', 'w') as outfile:
+		json.dump(data, outfile)
+
+	with open('labels.pkl', 'wb') as f:
+		pickle.dump(y, f)
+	len(logs)
+
+
+if __name__ == '__main__':
+	main()

--- a/validation_data/requirements.txt
+++ b/validation_data/requirements.txt
@@ -1,0 +1,7 @@
+elasticsearch2==2.5.0
+numpy==1.15.1
+
+
+
+
+

--- a/validation_data/requirments.txt
+++ b/validation_data/requirments.txt
@@ -1,0 +1,7 @@
+elasticsearch2==2.5.0
+numpy==1.15.1
+
+
+
+
+


### PR DESCRIPTION
Added new directory `validation_data` that includes the following:

`generate_validation_data.py` which will pull data from a user defined Elasticsearch endpoint and replace some entries with "fake" anomalies comprised of random character strings. It will save the data and corresponding labels to disk. 

`requirments.txt` includes the packages needed to run `generate_validation_data.py`

`README` contains instructions for downloading the data a running a local test of the anomaly detector.  