### PR TITLE
Adding logic to push trained models to s3.

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -20,6 +20,7 @@ scikit-learn = "*"
 scipy = "*"
 tqdm = "*"
 prometheus_client = "*"
+boto3 = "*"
 
 
 [requires]

--- a/anomaly_detector/anomaly_detector.py
+++ b/anomaly_detector/anomaly_detector.py
@@ -230,7 +230,7 @@ class AnomalyDetector():
         
         :return:
         """
-        if self.config.MODEL_BACKUP_SYSTEM == 's3':
+        if self.config.MODEL_STORE == 's3':
             session = boto3.session.Session()
             s3_key = os.getenv("CEPH_KEY")
             s3_secret = os.getenv("CEPH_SECRET")
@@ -242,17 +242,17 @@ class AnomalyDetector():
 
             s3_bucket = os.getenv("CEPH_BUCKET")
             t_timestamp = datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
-            s3_client.put_object(Bucket=s3_bucket, Key=(self.config.S3_MODEL_UPLOAD_PATH + t_timestamp + "/"))
-            _LOGGER.info("Created bucket: " + self.config.S3_MODEL_UPLOAD_PATH + t_timestamp + "/")
+            s3_client.put_object(Bucket=s3_bucket, Key=(self.config.MODEL_STORE_PATH + t_timestamp + "/"))
+            _LOGGER.info("Created bucket: " + self.config.MODEL_STORE_PATH + t_timestamp + "/")
             s3_client.upload_file(Filename='models/SOM.model', Bucket=s3_bucket,
-                                  Key=(self.config.S3_MODEL_UPLOAD_PATH + t_timestamp + '/SOM.model'))
+                                  Key=(self.config.MODEL_STORE_PATH + t_timestamp + '/SOM.model'))
             s3_client.upload_file(Filename='models/U-map.png', Bucket=s3_bucket,
-                                  Key=(self.config.S3_MODEL_UPLOAD_PATH + t_timestamp + '/U-map.png'))
+                                  Key=(self.config.MODEL_STORE_PATH + t_timestamp + '/U-map.png'))
             s3_client.upload_file(Filename='models/W2V.model', Bucket=s3_bucket,
-                                  Key=(self.config.S3_MODEL_UPLOAD_PATH + t_timestamp + '/W2V.model'))
+                                  Key=(self.config.MODEL_STORE_PATH + t_timestamp + '/W2V.model'))
             _LOGGER.info("Done uploading models to s3 complete")
         else:
-            _LOGGER.info("Must set MODEL_BACKUP_SYSTEM='s3' to save to s3")
+            _LOGGER.info("Must set MODEL_STORE='s3' to save to s3")
 
 
     def run(self):

--- a/anomaly_detector/config.py
+++ b/anomaly_detector/config.py
@@ -51,6 +51,8 @@ class Configuration():
     MODEL_PATH = ""
     W2V_MODEL_PATH_CALLABLE = join_w2v_model_path
     W2V_MODEL_PATH = ""
+    MODEL_BACKUP_SYSTEM= ""
+    S3_MODEL_UPLOAD_PATH = 'anomaly-detection/models/'
 
     # Number of seconds specifying how far to the past to go to load log entries for training TODO: move to es storage backend
     TRAIN_TIME_SPAN = 900

--- a/anomaly_detector/config.py
+++ b/anomaly_detector/config.py
@@ -51,8 +51,8 @@ class Configuration():
     MODEL_PATH = ""
     W2V_MODEL_PATH_CALLABLE = join_w2v_model_path
     W2V_MODEL_PATH = ""
-    MODEL_BACKUP_SYSTEM= ""
-    S3_MODEL_UPLOAD_PATH = 'anomaly-detection/models/'
+    MODEL_STORE= ""
+    MODEL_STORE_PATH = 'anomaly-detection/models/'
 
     # Number of seconds specifying how far to the past to go to load log entries for training TODO: move to es storage backend
     TRAIN_TIME_SPAN = 900

--- a/app.py
+++ b/app.py
@@ -31,7 +31,14 @@ def _main():
 
     parser = argparse.ArgumentParser()
     parser.add_argument("--mode", nargs='?', default="all")
+    parser.add_argument("--modelstore", nargs='?')
+
     args = parser.parse_args()
+    # Allow users to pick storage location we may want to
+    # store our models in google cloud storage or azure instead of s3 in the future
+    if args.modelstore=="s3":
+        _LOGGER.info("Model will be stored in s3")
+        anomaly_detector.config.MODEL_BACKUP_SYSTEM="s3"
 
     if args.mode == 'train':
         _LOGGER.info ("Performing training...")

--- a/app.py
+++ b/app.py
@@ -38,7 +38,7 @@ def _main():
     # store our models in google cloud storage or azure instead of s3 in the future
     if args.modelstore=="s3":
         _LOGGER.info("Model will be stored in s3")
-        anomaly_detector.config.MODEL_BACKUP_SYSTEM="s3"
+        anomaly_detector.config.MODEL_STORE="s3"
 
     if args.mode == 'train':
         _LOGGER.info ("Performing training...")


### PR DESCRIPTION
When training the model it would be good to have the ability to store the models in s3. Later we can tie this in with the inference to serve the models. We may have to design around how to roll out new versions of the model but in simple case. See visual below:

![image](https://user-images.githubusercontent.com/1269759/51385126-5f6e7c80-1b2f-11e9-9004-a9496a01bb68.png)


Later we can add different storage options like google cloud storage or azure storage if we want to store our models else where. For now this looks like a starter implementation.

Thoughts?