### PR TITLE
Adding script to build s2i and allowing for more env vars to setup mo…

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,7 +5,7 @@ Log Anomaly Detector
 from anomaly_detector.anomaly_detector import AnomalyDetector
 import sys
 import logging
-
+import os
 from anomaly_detector.config import Configuration
 import argparse
 _LOGGER = logging.getLogger()
@@ -36,14 +36,14 @@ def _main():
     args = parser.parse_args()
     # Allow users to pick storage location we may want to
     # store our models in google cloud storage or azure instead of s3 in the future
-    if args.modelstore=="s3":
+    if args.modelstore=="s3" or os.getenv("MODEL_STORE")== "s3":
         _LOGGER.info("Model will be stored in s3")
         anomaly_detector.config.MODEL_STORE="s3"
 
-    if args.mode == 'train':
+    if args.mode == 'train' or os.getenv("MODE") == "train":
         _LOGGER.info ("Performing training...")
         anomaly_detector.train()
-    elif args.mode == 'inference':
+    elif args.mode == 'inference' or os.getenv("MODE") == "inference":
         _LOGGER.info("Perform inference...")
         anomaly_detector.infer()
     elif args.mode == 'all':

--- a/build-s2i.sh
+++ b/build-s2i.sh
@@ -1,0 +1,14 @@
+#!/bin/sh
+VERSION="0.1-rc1"
+MAINTAINERS="Zak Hassan"
+COMPONENT="anomaly-detection-training"
+
+#cleaning up the image folder:
+
+DKR_HUB_NAME=quay.io/zmhassan/anomaly-detection-training:$VERSION
+IMAGE_NAME=anomaly-detector-train:$VERSION
+
+s2i build . docker.io/centos/python-36-centos7:latest $IMAGE_NAME
+
+docker tag  $IMAGE_NAME $DKR_HUB_NAME
+docker push  $DKR_HUB_NAME


### PR DESCRIPTION
When building the image we could use s2i binary instead of requiring us to use openshift to build the docker image. Also provided environment variables so users can use env vars instead of passing`--mode train --modelstore s3`