### PR TITLE
Resolving Env vars for build to work on local dataset and elasticsearch dataset

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -20,3 +20,9 @@ LADI_THRESHOLD=1.5 # float tunes the anomaly threshold based on the max value of
 
 LOCAL_DATA_FILE=validation_data/Hadoop_2k.json
 LOCAL_RESULTS_FILE=/tmp/local-results.txt
+LAD_S3_KEY=   # The s3 key <REPLACE_WITH_S3_KEY>
+LAD_S3_SECRET=   # The s3 secret <REPLACE_WITH_S3_SECRET>
+LAD_S3_HOST=http://localhost:8080 # The s3 endpoint url
+LAD_S3_BUCKET=      # The bucket name for s3 <REPLACE_WITH_BUCKET_NAME>
+LAD_MODEL_STORE=        # If s3 is not provided then it will write model files just to disk and not sync with s3
+LAD_MODE=train # set to 'inference' if you desire to serve models or set to 'train' if you want to create the models. (defaults to train and then serve for inference)

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,8 +5,8 @@ env:
   global:
     - PIPENV_VENV_IN_PROJECT=1
     - PIPENV_IGNORE_VIRTUALENVS=1
-    - LOCAL_DATA_FILE=validation_data/Hadoop_2k.json
-    - LOCAL_RESULTS_FILE=/tmp/local-results.txt
+    - LAD_LS_INPUT_PATH=validation_data/Hadoop_2k.json
+    - LAD_LS_OUTPUT_PATH=/tmp/local-results.txt
 # https://github.com/spulec/moto/issues/1771#issuecomment-412209380
 before_install:
   - export BOTO_CONFIG=/dev/null

--- a/anomaly_detector/anomaly_detector.py
+++ b/anomaly_detector/anomaly_detector.py
@@ -231,22 +231,17 @@ class AnomalyDetector():
         """
         if self.config.MODEL_STORE == 's3':
             session = boto3.session.Session()
-            s3_key = os.getenv("CEPH_KEY")
-            s3_secret = os.getenv("CEPH_SECRET")
-            s3_host = os.getenv("CEPH_HOST")
             s3_client = session.client(service_name='s3',
-                                       aws_access_key_id=s3_key,
-                                       aws_secret_access_key=s3_secret,
-                                       endpoint_url=s3_host, )
+                                       aws_access_key_id=self.config.S3_KEY,
+                                       aws_secret_access_key=self.config.S3_SECRET,
+                                       endpoint_url=self.config.S3_HOST, )
 
-            s3_bucket = os.getenv("CEPH_BUCKET")
+            s3_bucket = self.config.S3_BUCKET
             t_timestamp = datetime.datetime.now().strftime('%Y-%m-%d_%H-%M-%S')
             s3_client.put_object(Bucket=s3_bucket, Key=(self.config.MODEL_STORE_PATH + t_timestamp + "/"))
             _LOGGER.info("Created bucket: " + self.config.MODEL_STORE_PATH + t_timestamp + "/")
             s3_client.upload_file(Filename='models/SOM.model', Bucket=s3_bucket,
                                   Key=(self.config.MODEL_STORE_PATH + t_timestamp + '/SOM.model'))
-            s3_client.upload_file(Filename='models/U-map.png', Bucket=s3_bucket,
-                                  Key=(self.config.MODEL_STORE_PATH + t_timestamp + '/U-map.png'))
             s3_client.upload_file(Filename='models/W2V.model', Bucket=s3_bucket,
                                   Key=(self.config.MODEL_STORE_PATH + t_timestamp + '/W2V.model'))
             _LOGGER.info("Done uploading models to s3 complete")

--- a/anomaly_detector/config.py
+++ b/anomaly_detector/config.py
@@ -3,7 +3,6 @@
 
 import os
 import distutils
-
 import logging
 
 _LOGGER = logging.getLogger(__name__)
@@ -37,9 +36,6 @@ class Configuration():
     # One of the storage backends available in storage/ dir
     STORAGE_BACKEND = "local"
     # Location of local data
-    LOCAL_DATA_FILE = os.environ['LOCAL_DATA_FILE']
-    # Name of local results data
-    LOCAL_RESULTS_FILE = os.environ['LOCAL_RESULTS_FILE']
     # A directory where trained models will be stored
     MODEL_DIR = "./models/"
     MODE_DIR_CALLABLE = check_or_create_model_dir
@@ -53,7 +49,6 @@ class Configuration():
     W2V_MODEL_PATH = ""
     MODEL_STORE= ""
     MODEL_STORE_PATH = 'anomaly-detection/models/'
-
     # Number of seconds specifying how far to the past to go to load log entries for training TODO: move to es storage backend
     TRAIN_TIME_SPAN = 900
     # Maximum number of entries for training loaded from backend storage
@@ -77,6 +72,16 @@ class Configuration():
     INFER_LOOPS = 10
     # Maximum number of entries to be loaded for inference
     INFER_MAX_ENTRIES = 78862
+
+    # S3 credentials for storing model up to s3 post training.
+    S3_KEY = ""
+    S3_SECRET = ""
+    S3_HOST = ""
+    S3_BUCKET = ""
+    # local test dataset
+    LS_INPUT_PATH = ""
+    # Name of local results data
+    LS_OUTPUT_PATH =""
 
     prefix = "LAD"
 

--- a/anomaly_detector/storage/local_storage.py
+++ b/anomaly_detector/storage/local_storage.py
@@ -21,13 +21,12 @@ class LocalStorage(Storage):
     def __init__(self, configuration):
         """Initialize local storage backend."""
         self.config = configuration
-        configuration.storage = LSConfiguration()
 
     def retrieve(self, time_range, number_of_entries):
         """Retrieve data from local storage."""
         data = []
-        _LOGGER.info("Reading from %s" % self.config.storage.LS_INPUT_PATH)
-        if self.config.storage.LS_INPUT_PATH == "-":
+        _LOGGER.info("Reading from %s" % self.config.LS_INPUT_PATH)
+        if self.config.LS_INPUT_PATH == "-":
             cnt = 0
             for line in self._stdin():
                 try:
@@ -43,7 +42,7 @@ class LocalStorage(Storage):
             data = [x['_source'] for x in data]
             data_set = json_normalize(data)
         else:
-            with open(self.config.storage.LS_INPUT_PATH, 'r') as fp:
+            with open(self.config.LS_INPUT_PATH, 'r') as fp:
                 data = json.load(fp)
 
             data_set = json_normalize(data)
@@ -59,8 +58,8 @@ class LocalStorage(Storage):
 
     def store_results(self, data):
         """Store results."""
-        if len(self.config.storage.LS_OUTPUT_PATH) > 0:
-            with open(self.config.storage.LS_OUTPUT_PATH, 'a') as fp:
+        if len(self.config.LS_OUTPUT_PATH) > 0:
+            with open(self.config.LS_OUTPUT_PATH, 'a') as fp:
                 json.dump(data, fp)
         else:
             for item in data:
@@ -76,15 +75,3 @@ class LocalStorage(Storage):
             if len(stripped):
                 yield line.strip()
 
-
-class LSConfiguration(Configuration):
-    """Configuration for local storage."""
-
-    # Path to a file containing input data. If the value is '-' the input is expected on STDIN
-    LS_INPUT_PATH = Configuration.LOCAL_DATA_FILE #"validation_data/verification_data.json"
-    # Path to a file where the results will be stored. Results will be printed to STDOUT if empty
-    LS_OUTPUT_PATH = Configuration.LOCAL_RESULTS_FILE
-
-    def __init__(self):
-        """Initialize configuration."""
-        self.load()

--- a/app.py
+++ b/app.py
@@ -2,24 +2,24 @@
 Log Anomaly Detector
 """
 
-from anomaly_detector.anomaly_detector import AnomalyDetector
 import sys
 import logging
-
-from anomaly_detector.config import Configuration
+import os
 import argparse
+from anomaly_detector.anomaly_detector import AnomalyDetector
+from anomaly_detector.config import Configuration
 _LOGGER = logging.getLogger()
 _LOGGER.setLevel(logging.INFO)
 
 # create a logging format
-formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+FORMATTER = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
-sh = logging.StreamHandler(sys.stdout)
-sh.setFormatter(formatter)
-_LOGGER.addHandler(sh)
+SH = logging.StreamHandler(sys.stdout)
+SH.setFormatter(FORMATTER)
+_LOGGER.addHandler(SH)
 
-w2v_logger = logging.getLogger('gensim.models')
-w2v_logger.setLevel(logging.ERROR)
+W2V_LOGGER = logging.getLogger('gensim.models')
+W2V_LOGGER.setLevel(logging.ERROR)
 
 CONFIGURATION_PREFIX = "LAD"
 
@@ -34,16 +34,10 @@ def _main():
     parser.add_argument("--modelstore", nargs='?')
 
     args = parser.parse_args()
-    # Allow users to pick storage location we may want to
-    # store our models in google cloud storage or azure instead of s3 in the future
-    if args.modelstore=="s3":
-        _LOGGER.info("Model will be stored in s3")
-        anomaly_detector.config.MODEL_STORE="s3"
-
-    if args.mode == 'train':
-        _LOGGER.info ("Performing training...")
+    if args.mode == 'train' or os.getenv("LAD_MODE") == "train":
+        _LOGGER.info("Performing training...")
         anomaly_detector.train()
-    elif args.mode == 'inference':
+    elif args.mode == 'inference' or os.getenv("LAD_MODE") == "inference":
         _LOGGER.info("Perform inference...")
         anomaly_detector.infer()
     elif args.mode == 'all':


### PR DESCRIPTION
When building the image we could use s2i binary instead of requiring us to use openshift to build the docker image. Also provided environment variables so users can use env vars instead of passing`--mode train --modelstore s3`