### PR TITLE
Removing requirements.txt

### DIFF
--- a/fact_store/requirements.txt
+++ b/fact_store/requirements.txt
@@ -1,4 +1,0 @@
-Flask==0.12.4
-fastparquet
-s3fs
-git+https://github.com/jaybaird/python-bloomfilter

--- a/validation_data/requirements.txt
+++ b/validation_data/requirements.txt
@@ -1,7 +1,0 @@
-elasticsearch2==2.5.0
-numpy==1.15.1
-
-
-
-
-


### PR DESCRIPTION
### Background
Per issue #42 . Pipfile is the standard way for us to install dependencies. I've removed requirements.txt