### PR TITLE
Adding git dependency to be installed via setup.py as advised

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,13 @@
 """ Setup.py for packaging log-anomaly-detector as library """
-import os
 from setuptools import setup
 
-os.system('pip install git+https://github.com/sevamoo/SOMPY.git' +
-          '@76b60ebd6ffd550b0f7faaf632451dfd68827bf7')
-os.system('pip install ' +
-          'git+https://github.com/jaybaird/python-bloomfilter.git' +
-          '@2bbe01ad49965bf759e31781e6820408068862ac')
-REQUIRED_PKG = ["elasticsearch5", "gensim", "matplotlib", "numpy", "pandas",
-                "prometheus_client", "boto3", "Flask", "fastparquet",
-                "scikit-learn", "scipy", "tqdm",
-                "s3fs", "sompy", "pybloom"]
+REQUIRED_PKG = ["elasticsearch5", "gensim", "matplotlib", "numpy",
+                "pandas", "prometheus_client", "boto3", "Flask", "fastparquet",
+                "scikit-learn", "scipy", "tqdm", "s3fs",
+                "sompy", "pybloom"]
 
 setup(
-    name='lad-core',
+    name='lad-anomaly-detector',
     version='0.0.1',
     packages=['fact_store',
               'anomaly_detector',
@@ -33,6 +27,12 @@ setup(
     license='',
     author='AiOps',
     author_email='zak.hassan@redhat.com',
-    description='Log anomaly detector for streaming logs in kubernetes',
+    description='Log anomaly detector for streaming logs',
+    dependency_links=[
+        'git+https://github.com/sevamoo/SOMPY.git' +
+        '@76b60ebd6ffd550b0f7faaf632451dfd68827bf7',
+        'git+https://github.com/jaybaird/python-bloomfilter.git' +
+        '@2bbe01ad49965bf759e31781e6820408068862ac'
+    ],
     install_requires=REQUIRED_PKG
 )


### PR DESCRIPTION
## Description

Providing a fix to how installations happen via setup.py based on advise from @fridex 

## Related Issue

#94  

## Motivation and Context

We should add have setup.py download dependencies instead of making system calls with os module.

## How Has This Been Tested

run:
`python setup.py install`

 build the wheel file like this:

`python setup.py  bdist_wheel`
`pip install dist/lad_anomaly_detector-0.0.1-py2.py3-none-any.whl`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


## More Details

This is a fix based on advise from @fridex 