### PR TITLE
[ issue_112 ]-  pipenv is a tool that is resolving version for you, an…

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -4,31 +4,31 @@ verify_ssl = true
 name = "pypi"
 
 [dev-packages]
-pylint = "==2.3.1"
-"flake8" = "==3.7.7"
-pydocstyle = "==3.0.0"
-"pep8" = "==1.7.1"
-pytest = "==4.3.1"
-pytest-cov = "==2.6.1"
+pylint = "*"
+"flake8" = "*"
+pydocstyle = "*"
+"pep8" = "*"
+pytest = "*"
+pytest-cov = "*"
 
 [packages]
-"elasticsearch5" = "==5.5.5"
-gensim = "==3.7.1"
-matplotlib = "==3.0.3"
-numpy = "==1.16.2"
-pandas = "==0.24.2"
-scikit-learn = "==0.20.3"
-scipy = "==1.2.1"
-tqdm = "==4.31.1"
-prometheus-client = "==0.6.0"
+"elasticsearch5" = "*"
+gensim = "*"
+matplotlib = "*"
+numpy = "*"
+pandas = "*"
+scikit-learn = "*"
+scipy = "*"
+tqdm = "*"
+prometheus-client = "*"
 sompy = {editable = true, ref = "76b60ebd6ffd550b0f7faaf632451dfd68827bf7", git = "https://github.com/sevamoo/SOMPY.git"}
-boto3 = "==1.9.115"
-Flask = "==1.0.2"
+boto3 = "*"
+Flask = "*"
 pybloom = {editable = true, ref = "2bbe01ad49965bf759e31781e6820408068862ac", git = "https://github.com/jaybaird/python-bloomfilter.git"}
-Click = "==7.0"
-pyyaml = "==5.1"
-Flask-SQLAlchemy = "==2.3.2"
-PyMySQL = "==0.9.3"
+Click = "*"
+pyyaml = "*"
+Flask-SQLAlchemy = "*"
+PyMySQL = "*"
 
 
 [requires]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "d3772a4fd55ee301871ea31b9934335da163b5db6ad9a7667f4d9778b999db5f"
+            "sha256": "b1872df54d1f4a278dbef2f9bac81f2092776bb21a2fb0c8b7822f255dc0abc1"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -31,18 +31,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:1b4a86e1167ba7cbb9dbf2a0a0b86447b35a2b901ae5aace75b8196631680957",
-                "sha256:f5b12367c530dac45782251b672f1e911da5c74285f89850b0f4f5694b8c388c"
+                "sha256:2e527686a72ff5fed8275e897df63fadbdca6d4d47f651d898dee89ba9b9eb4d",
+                "sha256:fa93b78f2530c748ad60e46250d2e7162deabc75db4e4e7c18500b2daa95855f"
             ],
             "index": "pypi",
-            "version": "==1.9.115"
+            "version": "==1.9.123"
         },
         "botocore": {
             "hashes": [
-                "sha256:57b98300ed264d1e5abdc22621a36d952488c7b0a1ecad82a3d58e84d2128a8f",
-                "sha256:f0eeeb89bbe0464da9499c2705c2fe6ac57ae0276b73b38ffb8638b217887139"
+                "sha256:7982ab3b3da1f7f2f23f0a12fbd34fe8efc514b53bbe61b536a61884a51db25c",
+                "sha256:da94f6087a075ecd01446a9ed4cd4c1d0c356c2c28e69095b23ed4c8814833f4"
             ],
-            "version": "==1.12.121"
+            "version": "==1.12.123"
         },
         "bz2file": {
             "hashes": [
@@ -653,11 +653,11 @@
         },
         "more-itertools": {
             "hashes": [
-                "sha256:0125e8f60e9e031347105eb1682cef932f5e97d7b9a1a28d9bf00c22a5daef40",
-                "sha256:590044e3942351a1bdb1de960b739ff4ce277960f2425ad4509446dbace8d9d1"
+                "sha256:2112d2ca570bb7c3e53ea1a35cd5df42bb0fd10c45f0fb97178679c3c03d64c7",
+                "sha256:c3e4748ba1aad8dba30a4886b0b1a2004f9a863837b8654e7059eebf727afa5a"
             ],
             "markers": "python_version > '2.7'",
-            "version": "==6.0.0"
+            "version": "==7.0.0"
         },
         "pep8": {
             "hashes": [


### PR DESCRIPTION
# PR Details

We are using pipfile.lock for handling our dependencies. We should make the Pipfile versions be "*" and the pipfile.lock will manage our versions.

## Description

@goern Advised on us setting our versions to ="*" as we have the Pipfile.lock that will handle our versions

## Related Issue

Fixes #112 
## Motivation and Context

We want to adopt Thoth bots and CI tooling to test for validate code quality.

## How Has This Been Tested

```bash
pipenv update
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


## More Details
None