### PR TITLE
Removing dependency on elasticsearch env vars. Defaulting to using configmap with yaml to deploy

### DIFF
--- a/anomaly_detector/config.py
+++ b/anomaly_detector/config.py
@@ -92,6 +92,21 @@ class Configuration(Borg):
     # Name of local results data
     LS_OUTPUT_PATH = ""
 
+    # ElasticSearch endpoint URL
+    ES_ENDPOINT = ""
+    # Path to a directory where cert and key (es.crt and es.key) are stored for authentication
+    ES_CERT_DIR = ""
+    # If True, connect using ssl
+    ES_USE_SSL = True
+    # If True, verify SSL certificates
+    ES_VERIFY_CERTS = False
+    # ElasticSearch index name where results will be pushed to
+    ES_TARGET_INDEX = ""
+    # ElasticSearch index name where log entries will be pulled from
+    ES_INPUT_INDEX = ""
+    # JSON representing a query passed to ElasticSearch to match the data
+    ES_QUERY = ""
+
     prefix = "LAD"
 
     def __init__(self, prefix=None, config_yaml=None):

--- a/anomaly_detector/storage/es_storage.py
+++ b/anomaly_detector/storage/es_storage.py
@@ -24,37 +24,36 @@ class ESStorage(Storage):
 
     def __init__(self, configuration):
         """Initialize Elasticsearch storage backend."""
-        super(ESStorage, self).__init__(configuration)
-        self.config.storage = ESConfiguration()
+        self.config = configuration
         self._connect()
 
     def _connect(self):
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
-        if len(self.config.storage.ES_CERT_DIR) and os.path.isdir(self.config.storage.ES_CERT_DIR):
+        if len(self.config.ES_CERT_DIR) and os.path.isdir(self.config.ES_CERT_DIR):
             _LOGGER.warn(
                 "Using cert and key in %s for connection to %s (verify_certs=%s)."
                 % (
-                    self.config.storage.ES_CERT_DIR,
-                    self.config.storage.ES_ENDPOINT,
-                    self.config.storage.ES_VERIFY_CERTS,
+                    self.config.ES_CERT_DIR,
+                    self.config.ES_ENDPOINT,
+                    self.config.ES_VERIFY_CERTS,
                 )
             )
             self.es = Elasticsearch(
-                self.config.storage.ES_ENDPOINT,
-                use_ssl=self.config.storage.ES_USE_SSL,
-                verify_certs=self.config.storage.ES_VERIFY_CERTS,
-                client_cert=os.path.join(self.config.storage.ES_CERT_DIR, "es.crt"),
-                client_key=os.path.join(self.config.storage.ES_CERT_DIR, "es.key"),
+                self.config.ES_ENDPOINT,
+                use_ssl=self.config.ES_USE_SSL,
+                verify_certs=self.config.ES_VERIFY_CERTS,
+                client_cert=os.path.join(self.config.ES_CERT_DIR, "es.crt"),
+                client_key=os.path.join(self.config.ES_CERT_DIR, "es.key"),
                 timeout=60,
                 max_retries=2,
             )
         else:
             _LOGGER.warn("Conecting to ElasticSearch without authentication.")
-            print(self.config.storage.ES_USE_SSL)
+            print(self.config.ES_USE_SSL)
             self.es = Elasticsearch(
-                self.config.storage.ES_ENDPOINT,
-                use_ssl=self.config.storage.ES_USE_SSL,
-                verify_certs=self.config.storage.ES_VERIFY_CERTS,
+                self.config.ES_ENDPOINT,
+                use_ssl=self.config.ES_USE_SSL,
+                verify_certs=self.config.ES_VERIFY_CERTS,
                 timeout=60,
                 max_retries=2,
             )
@@ -68,7 +67,7 @@ class ESStorage(Storage):
 
     def retrieve(self, time_range: int, number_of_entires: int):
         """Retrieve data from ES."""
-        index_in = self._prep_index_name(self.config.storage.ES_INPUT_INDEX)
+        index_in = self._prep_index_name(self.config.ES_INPUT_INDEX)
 
         query = {
             "sort": {"@timestamp": {"order": "desc"}},
@@ -86,12 +85,12 @@ class ESStorage(Storage):
             "Reading in max %d log entries in last %d seconds from %s",
             number_of_entires,
             time_range,
-            self.config.storage.ES_ENDPOINT,
+            self.config.ES_ENDPOINT,
         )
 
         query["size"] = number_of_entires
         query["query"]["bool"]["must"][1]["range"]["@timestamp"]["gte"] = "now-%ds" % time_range
-        query["query"]["bool"]["must"][0]["query_string"]["query"] = self.config.storage.ES_QUERY
+        query["query"]["bool"]["must"][0]["query_string"]["query"] = self.config.ES_QUERY
 
         es_data = self.es.search(index_in, body=json.dumps(query))
         if es_data["hits"]["total"] == 0:
@@ -108,31 +107,8 @@ class ESStorage(Storage):
 
     def store_results(self, data):
         """Store results back to ES."""
-        index_out = self._prep_index_name(self.config.storage.ES_TARGET_INDEX)
+        index_out = self._prep_index_name(self.config.ES_TARGET_INDEX)
 
         actions = [{"_index": index_out, "_type": "log", "_source": data[i]} for i in range(len(data))]
 
         helpers.bulk(self.es, actions, chunk_size=int(len(data) / 4) + 1)
-
-
-class ESConfiguration(Configuration):
-    """Elasticsearch configuration."""
-
-    # ElasticSearch endpoint URL
-    ES_ENDPOINT = ""
-    # Path to a directory where cert and key (es.crt and es.key) are stored for authentication
-    ES_CERT_DIR = ""
-    # If True, connect using ssl
-    ES_USE_SSL = True
-    # If True, verify SSL certificates
-    ES_VERIFY_CERTS = False
-    # ElasticSearch index name where results will be pushed to
-    ES_TARGET_INDEX = ""
-    # ElasticSearch index name where log entries will be pulled from
-    ES_INPUT_INDEX = ""
-    # JSON representing a query passed to ElasticSearch to match the data
-    ES_QUERY = ""
-
-    def __init__(self):
-        """Initialize ES configuration."""
-        self.load()


### PR DESCRIPTION
## Description


Currently we want to deploy LAD with elasticsearch as the data input provider. We would like to make it configurable via yaml file with configmap. Currently there is bug and this PR should remove the dependency to inject env vars.

## Related Issue

Fixes #119  

## Motivation and Context

We would like to be able to run LAD with different configmaps to run our application. Currently there is a dependency on env vars.

## How Has This Been Tested
Update .env_config.yaml with elasticpoint and it should connect. Previously this would fail with host not found error.
```bash
python app.py run --config-yaml .env_config.yaml
```

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Docs change / refactoring / dependency upgrade
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


## More Details
