### PR TITLE
Interface for storage class fails due to bug

### DIFF
--- a/anomaly_detector/anomaly_detector.py
+++ b/anomaly_detector/anomaly_detector.py
@@ -188,7 +188,7 @@ class AnomalyDetector:
                 s["anomaly_score"] = dist[i]
                 # Record anomaly event in fact_store and
 
-                if dist[i] > threshold and {"message": s["message"]} not in false_positives:
+                if dist[i] > threshold:
                     ANOMALY_COUNT.inc()
 
                     s["anomaly"] = 1

--- a/anomaly_detector/storage/es_storage.py
+++ b/anomaly_detector/storage/es_storage.py
@@ -65,7 +65,7 @@ class ESStorage(Storage):
         index = prefix + date
         return index
 
-    def retrieve(self, time_range: int, number_of_entires: int, fp=None):
+    def retrieve(self, time_range: int, number_of_entries: int, false_data=None):
         """Retrieve data from ES."""
         index_in = self._prep_index_name(self.config.ES_INPUT_INDEX)
 
@@ -83,12 +83,12 @@ class ESStorage(Storage):
         }
         _LOGGER.info(
             "Reading in max %d log entries in last %d seconds from %s",
-            number_of_entires,
+            number_of_entries,
             time_range,
             self.config.ES_ENDPOINT,
         )
 
-        query["size"] = number_of_entires
+        query["size"] = number_of_entries
         query["query"]["bool"]["must"][1]["range"]["@timestamp"]["gte"] = "now-%ds" % time_range
         query["query"]["bool"]["must"][0]["query_string"]["query"] = self.config.ES_QUERY
 

--- a/anomaly_detector/storage/storage.py
+++ b/anomaly_detector/storage/storage.py
@@ -17,7 +17,7 @@ class Storage(object):
         self.config = configuration
 
     @abstractmethod
-    def retrieve(self, time_range, number_of_entires):
+    def retrieve(self, time_range, number_of_entries, false_data):
         """Retrieve data from storage and return them as a pandas dataframe."""
         pass
 


### PR DESCRIPTION
## Description

When we use the storage class it needs the proper fields names to match across all classes inheriting the base. 


Fixes
#135
