### PR TITLE
Adding inmemory default for sqlite for cross platform compatibility

### DIFF
--- a/anomaly_detector/fact_store/fact_store_api.py
+++ b/anomaly_detector/fact_store/fact_store_api.py
@@ -12,7 +12,7 @@ class FactStore(object):
 
     def __init__(self, autocreate=True):
         """We initialize our sqlalchemy connection and setup the database."""
-        engine = create_engine(os.getenv("SQL_CONNECT", "sqlite:////tmp/test.db"), echo=True)
+        engine = create_engine(os.getenv("SQL_CONNECT", "sqlite://"), echo=True)
         try:
             if autocreate is True:
                 logging.info("Creating tables")


### PR DESCRIPTION
**Describe the bug**
We can use inmemory sqlite instead as that is cleaner then creating a file on system. 
`sqlite://`
Also for windows users this program would crash as it uses linux filepath.


## Fixes 
#165 