### PR TITLE
Ensure single instance of Task Queue exists in the lifetime of application.

### DIFF
--- a/anomaly_detector/jobs/tasks.py
+++ b/anomaly_detector/jobs/tasks.py
@@ -4,6 +4,7 @@ import logging
 from abc import ABCMeta, abstractmethod
 import time
 from prometheus_client import Gauge, Summary, Counter, Histogram
+
 TRAINING_COUNT = Counter("aiops_lad_train_count", "count of training runs")
 INFER_COUNT = Counter("aiops_lad_inference_count", "count of inference runs")
 
@@ -82,7 +83,24 @@ class SomInferCommand(AbstractCommand):
         return 0
 
 
-class TaskQueue:
+class Singleton(type):
+    """Singleton ensures  that a single instance will exist of this class."""
+
+    def __init__(self, *args, **kwargs):
+        """Create single instance if none exists."""
+        self.__state = None
+        super().__init__(*args, **kwargs)
+
+    def __call__(self, *args, **kwargs):
+        """Overwriting the call method when this is called."""
+        if self.__state is None:
+            self.__state = super().__call__(*args, **kwargs)
+            return self.__state
+        else:
+            return self.__state
+
+
+class TaskQueue(metaclass=Singleton):
     """Task manager is a custom."""
 
     count = 0
@@ -115,3 +133,8 @@ class TaskQueue:
     def __len__(self):
         """Number of steps in queue."""
         return len(self.steps)
+
+    def clear(self):
+        """Reset the values."""
+        self.steps = []
+        self.count = 0

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -24,6 +24,7 @@ class TestTaskManager(TestCase):
         self.assertNotEqual(mgr.count, TASKS_IN_QUEUE)
         mgr.execute_steps()
         self.assertEqual(mgr.count, TASKS_IN_QUEUE)
+        mgr.clear()
 
     def test_invalid_command(self):
         """Test case for validating that when we train a model and add it to task queue that it will run."""
@@ -36,6 +37,7 @@ class TestTaskManager(TestCase):
         mock = mock_func()
         with self.assertRaises(TypeError) as context:
             mgr.add_steps(mock)
+        mgr.clear()
 
     def test_valid_command(self):
         """Test case for validating that when we train a model and add it to task queue that it will run."""
@@ -51,3 +53,4 @@ class TestTaskManager(TestCase):
         self.assertNotEqual(mgr.count, TASKS_IN_QUEUE)
         mgr.execute_steps()
         self.assertEqual(mgr.count, TASKS_IN_QUEUE)
+        mgr.clear()


### PR DESCRIPTION
## Description:
An api should enforce rules for how users will interact with it. As Task queue is very core to Log anomaly detector. We should have it be a singleton class. Which only has 1 instance. 