### PR TITLE
Adding feature to allow for offline testing without triggering alerts

### DIFF
--- a/anomaly_detector/config.py
+++ b/anomaly_detector/config.py
@@ -108,6 +108,9 @@ class Configuration(Borg):
     # JSON representing a query passed to ElasticSearch to match the data
     ES_QUERY = ""
 
+    # For testing offline training and inference without triggering emails
+    PREDICTION_ALERT = True
+
     prefix = "LAD"
 
     def __init__(self, prefix=None, config_yaml=None):
@@ -153,7 +156,7 @@ class Configuration(Borg):
     def set_property(self, prop, val):
         """Set the correct datatype."""
         typ = type(getattr(self, prop))
-        if val:
+        if val is not None:
 
             if typ is int:
                 setattr(self, prop, int(val))

--- a/anomaly_detector/jobs/tasks.py
+++ b/anomaly_detector/jobs/tasks.py
@@ -68,7 +68,9 @@ class SomInferCommand(AbstractCommand):
             logging.info("%d logs loaded from the last %d seconds", len(data),
                          self.model_adapter.storage_adapter.INFER_TIME_SPAN)
             results = self.model_adapter.predict(data, json_logs, threshold)
-            self.model_adapter.storage_adapter.persist_data(results)
+            # This is for offline testing of the ML Training and Infer which results in trigger emails.
+            if self.model_adapter.storage_adapter.PREDICTION_ALERT is True:
+                self.model_adapter.storage_adapter.persist_data(results)
             # Inference done, increase counter
             infer_loops += 1
             now = time.time()


### PR DESCRIPTION
## Description

When testing LAD offline we may trigger alerts to users. We should make it possible to run offline testing without sending out alerts emails. By setting `PREDICTION_ALERT=False` you will have the ability to experiment or try new features without triggering emails.

## Issue
fixes #190 