### PR TITLE
Add preliminary unit tests for SOM

### DIFF
--- a/tests/test_som.py
+++ b/tests/test_som.py
@@ -1,0 +1,47 @@
+"""Validates if training was successful."""
+from anomaly_detector.adapters.som_model_adapter import SomModelAdapter
+from anomaly_detector.adapters.som_storage_adapter import SomStorageAdapter
+from anomaly_detector.jobs.tasks import SomTrainCommand, SomInferCommand
+from anomaly_detector.config import Configuration
+
+import pytest
+import random
+random.seed(55)
+
+
+CONFIGURATION_PREFIX = "LAD"
+
+
+@pytest.fixture()
+def config():
+    """Initialize configurations before testing."""
+    config = Configuration(prefix=CONFIGURATION_PREFIX, config_yaml="config_files/.env_config.yaml")
+
+    return config
+
+
+def test_output_values(config):
+    """Test that all distance values in training set are less than or equal to 1 on Hadoop_2k.json."""
+    storage_adapter = SomStorageAdapter(config=config, feedback_strategy=None)
+    model_adapter = SomModelAdapter(storage_adapter=storage_adapter)
+    tc = SomTrainCommand(node_map=2, model_adapter=model_adapter)
+    result, dist = tc.execute()
+    assert sum(dist) <= 2000
+
+
+def test_output_length(config):
+    """Test that correct number of outputs are generated with Hadoop_2k.json."""
+    storage_adapter = SomStorageAdapter(config=config, feedback_strategy=None)
+    model_adapter = SomModelAdapter(storage_adapter=storage_adapter)
+    tc = SomTrainCommand(node_map=2, model_adapter=model_adapter)
+    result, dist = tc.execute()
+    assert len(dist) == 2000
+
+
+def test_model_shape(config):
+    """Test that the trained model size is expected based on given parameters."""
+    storage_adapter = SomStorageAdapter(config=config, feedback_strategy=None)
+    model_adapter = SomModelAdapter(storage_adapter=storage_adapter)
+    tc = SomTrainCommand(node_map=2, model_adapter=model_adapter)
+    result, dist = tc.execute()
+    assert model_adapter.model.model.shape[0:2] == (2, 2)


### PR DESCRIPTION
This PR adds some basic unit tests for the SOM model, ensuring that the model outputs the correct number of  metrics for the input data, confirms that the sum of the distance values is less than the number of values (heuristic for all values being less than or equal to 1), and that the shape of the output map is as expected. 

More sophisticated unit tests can be developed for in a future PR, but this will also serve as a template for contributors who develop tests for alternative anomaly detection models.   