### PR TITLE
Adding better schema for storing facts for multiple services.

### DIFF
--- a/anomaly_detector/fact_store/app.py
+++ b/anomaly_detector/fact_store/app.py
@@ -2,6 +2,7 @@
 import logging
 from flask import Flask, request, render_template, jsonify, make_response
 from anomaly_detector.fact_store.fact_store_api import FactStore
+import os
 
 app = Flask(__name__, static_folder="static")
 
@@ -38,9 +39,12 @@ def feedback():
     """Feedback Service to provide user input on which false predictions this model provided."""
     try:
         content = request.json
+        # When deploying fact_store per customer you should set env var
+        customer_id = os.getenv("CUSTOMER_ID")
         logging.info("id: {} ".format(content["lad_id"]))
         logging.info("anomaly: {} ".format(content["is_anomaly"]))
         logging.info("message: {} ".format(content["message"]))
+        logging.info("customer_id: {} ".format(customer_id))
 
         if not content["lad_id"] or not content["is_anomaly"]:
             raise Exception(
@@ -53,7 +57,8 @@ def feedback():
         # Note id is the prediction id that is found in the email.
         if (
                 fs.write_feedback(
-                    predict_id=content["lad_id"], message=content["message"], anomaly_status=bool(content["is_anomaly"])
+                    predict_id=content["lad_id"], message=content["message"],
+                    anomaly_status=bool(content["is_anomaly"]), customer_id=customer_id
                 )
                 is False
         ):

--- a/anomaly_detector/fact_store/fact_store_api.py
+++ b/anomaly_detector/fact_store/fact_store_api.py
@@ -22,7 +22,7 @@ class FactStore(object):
         Session = sessionmaker(bind=engine)
         self.session = Session()
 
-    def write_feedback(self, predict_id, message, anomaly_status):
+    def write_feedback(self, predict_id, message, anomaly_status, customer_id):
         """Service for storage of metadata in parquet.
 
         :param predict_id: predict Id where the anomaly details are stored
@@ -33,7 +33,8 @@ class FactStore(object):
         """
         # Adding id to bloom filter so we don't have to hit the database every time
 
-        feedback = FeedbackModel(predict_id=predict_id, message=message, reported_anomaly_status=anomaly_status)
+        feedback = FeedbackModel(predict_id=predict_id, message=message, reported_anomaly_status=anomaly_status,
+                                 customer_id=customer_id)
         self.session.add(feedback)
         self.session.commit()
         logging.info("Persisted ID: {} recorded in FStore".format(feedback.id))

--- a/anomaly_detector/fact_store/model.py
+++ b/anomaly_detector/fact_store/model.py
@@ -1,5 +1,6 @@
 """Model orm table descriptor."""
-from sqlalchemy import Column, Integer, String, Float, Boolean, Sequence, ForeignKey
+import datetime
+from sqlalchemy import Column, Integer, String, Boolean, Sequence, DateTime
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import relationship
 
@@ -17,6 +18,10 @@ class FeedbackModel(Base):
     message = Column(String(2000), nullable=False)
     # Required
     reported_anomaly_status = Column(Boolean, nullable=False)
+    # Default track last date of
+    created_date = Column(DateTime, default=datetime.datetime.utcnow)
+    # CustomerID
+    customer_id = Column(String(255), nullable=False)
 
     def __repr__(self):
         """Repr - Used for debugging to see repr output."""

--- a/scripts/run-web-ui.sh
+++ b/scripts/run-web-ui.sh
@@ -1,2 +1,3 @@
+export CUSTOMER_ID="#1234567"
 export SQL_CONNECT="mysql+pymysql://zak:password@localhost/factstore"
 python ../app.py --metric-port 8081 ui

--- a/tests/test_factstore.py
+++ b/tests/test_factstore.py
@@ -5,12 +5,16 @@ from anomaly_detector.fact_store.model import FeedbackModel
 
 def test_feedback_inserted():
     """Test inserting events into the fact_store."""
+    CUSTOMER_ID = "#123456"
     fact_store = FactStore(True)
     fact_store.session.query(FeedbackModel).delete()
     fact_store.write_feedback(
-        predict_id="a2b35c5b-016d-4e2c-8ec5-87d1b962b2f8", message="222JSJSJJS", anomaly_status=True
+        predict_id="a2b35c5b-016d-4e2c-8ec5-87d1b962b2f8", message="222JSJSJJS",
+        anomaly_status=True, customer_id=CUSTOMER_ID
     )
-    fact_store.write_feedback(predict_id="18bd090d-ae27-4b19-a0db-ed5f589b4e2e", message="SSJJSJS", anomaly_status=True)
-    fact_store.write_feedback(predict_id="74a6b1bd-efea-4e7b-87a9-8f7330885160", message="AJJSJS", anomaly_status=False)
+    fact_store.write_feedback(predict_id="18bd090d-ae27-4b19-a0db-ed5f589b4e2e",
+                              customer_id=CUSTOMER_ID, message="SSJJSJS", anomaly_status=True)
+    fact_store.write_feedback(predict_id="74a6b1bd-efea-4e7b-87a9-8f7330885160", message="AJJSJS",
+                              customer_id=CUSTOMER_ID, anomaly_status=False)
     items = fact_store.readall_feedback()
     assert len(items) is 3


### PR DESCRIPTION
# Description

When deploying Fact Store for storing metadata for multiple services owned by a customer. We should firstly track when the fact was stored. And for which project. This way we can have 1 shared instance of factstore.