### PR TITLE
update setup.py for not utf-8 system

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 """ Setup.py for packaging log-anomaly-detector as library """
 from setuptools import setup, find_packages
 
-with open("README.rst", "r") as fh:
+with open("README.rst", "r", encoding='utf-8') as fh:
     long_description = fh.read()
 
 REQUIRED_PKG = [

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 """ Setup.py for packaging log-anomaly-detector as library """
 from setuptools import setup, find_packages
 
-with open("README.rst", "r", encoding='utf-8') as fh:
+with open("README.rst", "r", encoding="utf-8") as fh:
     long_description = fh.read()
 
 REQUIRED_PKG = [


### PR DESCRIPTION
At the Windows system with Chinese, default encode is `gbk`, and `pip install` failed with:

```
UnicodeDecodeError: 'gbk' codec can't decode byte 0x9d in position 811: illegal multibyte sequence
```

![Snipaste_2019-10-09_17-58-41](https://user-images.githubusercontent.com/1682158/66472362-a4707f80-eabf-11e9-81f9-ccb8ac96d4b6.png)

open `README.rst` with `encoding='utf-8'` will fix this.