### PR TITLE
updated Makefile to point to new demo repo & template api ver

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,7 @@ oc_delete_lad:
 	oc process -f ./openshift/log-anomaly-detector-minishift.yaml -p FACT_STORE_URL=${FACTSTORE_ROUTE} -p ES_ENDPOINT="lad-elasticsearch-service.${NAMESPACE}.svc:9200"| oc delete -f - -n ${NAMESPACE}
 
 oc_deploy_demo_app:
-	oc process -f https://raw.githubusercontent.com/HumairAK/anomaly-detection-demo-app/master/openshift/ad_demo.yaml | oc apply -f - -n ${NAMESPACE}
+	oc process -f https://raw.githubusercontent.com/AICoE/anomaly-detection-demo-app/master/openshift/ad_demo.yaml | oc apply -f - -n ${NAMESPACE}
 
 oc_build_elastalert_image:
 	oc process -f ./openshift/elastalert/lad-elastalert-buildconfig.yaml | oc apply -f - -n ${NAMESPACE}

--- a/openshift/aiops_lad_core.elasticsearch.storage.yaml
+++ b/openshift/aiops_lad_core.elasticsearch.storage.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: v1
+apiVersion: template.openshift.io/v1
 kind: Template
 metadata:
   name: elasticsearch-deployment-template


### PR DESCRIPTION
Demo repo moved to the AICOE group, updating links. And the template api version should be template.openshift.io/v1 not v1. 