### PR TITLE
added e2e tests

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -12,6 +12,7 @@ pytest = "*"
 pytest-cov = "*"
 black = "*"
 coala = "*"
+openshift = "*"
 
 [packages]
 "elasticsearch5" = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e79933bd503a89832bb6879fd60febe5597d974edd11068785e7ef418c1adf31"
+            "sha256": "0b37491ce5027e925165047c09e4fbe173756634557afe374b53869df317dcdb"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -25,18 +25,18 @@
         },
         "boto3": {
             "hashes": [
-                "sha256:839285fbd6f3ab16170af449ae9e33d0eccf97ca22de17d9ff68b8da2310ea06",
-                "sha256:d93f1774c4bc66e02acdda2067291acb9e228a035435753cb75f83ad2904cbe3"
+                "sha256:2edee79d0e78c08b6d14d4dd91c0e4b3438dd4c90c859f06a397268b1cac17b2",
+                "sha256:3cd2078144c10417eb04e4bb263ea8e50a21c4aceafb52db33e3fe71e73b48aa"
             ],
             "index": "pypi",
-            "version": "==1.9.253"
+            "version": "==1.10.0"
         },
         "botocore": {
             "hashes": [
-                "sha256:3baf129118575602ada9926f5166d82d02273c250d0feb313fc270944b27c48b",
-                "sha256:dc080aed4f9b220a9e916ca29ca97a9d37e8e1d296fe89cbaeef929bf0c8066b"
+                "sha256:507b8f13583a64ec2c9c112ff6e3dd8b548060adc7e1f57f25fda9fa34c2dfdb",
+                "sha256:c4b2ffb0f6ed7169beb260485bf5a42ee72a0a02f49f48b0557ed5e32bcf9e79"
             ],
-            "version": "==1.12.253"
+            "version": "==1.13.0"
         },
         "certifi": {
             "hashes": [
@@ -695,6 +695,13 @@
             "index": "pypi",
             "version": "==19.3b0"
         },
+        "cachetools": {
+            "hashes": [
+                "sha256:428266a1c0d36dc5aca63a2d7c5942e88c2c898d72139fca0e97fdd2380517ae",
+                "sha256:8ea2d3ce97850f31e4a08b0e2b5e6c34997d7216a9d2c98e0f3978630d4da69a"
+            ],
+            "version": "==3.1.1"
+        },
         "certifi": {
             "hashes": [
                 "sha256:e4f3620cfea4f83eedc95b24abd9cd56f3c4b146dd0177e83a21b4eb49e21e50",
@@ -782,6 +789,13 @@
             ],
             "version": "==0.4.0"
         },
+        "dictdiffer": {
+            "hashes": [
+                "sha256:97cf4ef98ebc1acf737074aed41e379cf48ab5ff528c92109dfb8e2e619e6809",
+                "sha256:b3ad476fc9cca60302b52c50e1839342d2092aeaba586d69cbf9249f87f52463"
+            ],
+            "version": "==0.8.0"
+        },
         "entrypoints": {
             "hashes": [
                 "sha256:589f874b313739ad35be6e0cd7efde2a4e9b6fea91edcc34e58ecbb8dbe56d19",
@@ -796,6 +810,13 @@
             ],
             "index": "pypi",
             "version": "==3.7.8"
+        },
+        "google-auth": {
+            "hashes": [
+                "sha256:0f7c6a64927d34c1a474da92cfc59e552a5d3b940d3266606c6a28b72888b9e4",
+                "sha256:20705f6803fd2c4d1cc2dcb0df09d4dfcb9a7d51fd59e94a3a28231fd93119ed"
+            ],
+            "version": "==1.6.3"
         },
         "idna": {
             "hashes": [
@@ -818,6 +839,20 @@
                 "sha256:6e811fcb295968434526407adb8796944f1988c5b65e8139058f2014cbe100fd"
             ],
             "version": "==4.3.21"
+        },
+        "jinja2": {
+            "hashes": [
+                "sha256:74320bb91f31270f9551d46522e33af46a80c3d619f4a4bf42b3164d30b5911f",
+                "sha256:9fe95f19286cfefaa917656583d020be14e7859c6b0252588391e47db34527de"
+            ],
+            "version": "==2.10.3"
+        },
+        "kubernetes": {
+            "hashes": [
+                "sha256:3770a496663396ad1def665eeadb947b3f45217a08b64b10c01a57e981ac8592",
+                "sha256:a6dee02a1b39ea4bb9c4c2cc415ea0ada33d8ea0a920f7d4fb6d166989dcac01"
+            ],
+            "version": "==10.0.1"
         },
         "lazy-object-proxy": {
             "hashes": [
@@ -848,6 +883,39 @@
             ],
             "version": "==3.4.0"
         },
+        "markupsafe": {
+            "hashes": [
+                "sha256:00bc623926325b26bb9605ae9eae8a215691f33cae5df11ca5424f06f2d1f473",
+                "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161",
+                "sha256:09c4b7f37d6c648cb13f9230d847adf22f8171b1ccc4d5682398e77f40309235",
+                "sha256:1027c282dad077d0bae18be6794e6b6b8c91d58ed8a8d89a89d59693b9131db5",
+                "sha256:24982cc2533820871eba85ba648cd53d8623687ff11cbb805be4ff7b4c971aff",
+                "sha256:29872e92839765e546828bb7754a68c418d927cd064fd4708fab9fe9c8bb116b",
+                "sha256:43a55c2930bbc139570ac2452adf3d70cdbb3cfe5912c71cdce1c2c6bbd9c5d1",
+                "sha256:46c99d2de99945ec5cb54f23c8cd5689f6d7177305ebff350a58ce5f8de1669e",
+                "sha256:500d4957e52ddc3351cabf489e79c91c17f6e0899158447047588650b5e69183",
+                "sha256:535f6fc4d397c1563d08b88e485c3496cf5784e927af890fb3c3aac7f933ec66",
+                "sha256:62fe6c95e3ec8a7fad637b7f3d372c15ec1caa01ab47926cfdf7a75b40e0eac1",
+                "sha256:6dd73240d2af64df90aa7c4e7481e23825ea70af4b4922f8ede5b9e35f78a3b1",
+                "sha256:717ba8fe3ae9cc0006d7c451f0bb265ee07739daf76355d06366154ee68d221e",
+                "sha256:79855e1c5b8da654cf486b830bd42c06e8780cea587384cf6545b7d9ac013a0b",
+                "sha256:7c1699dfe0cf8ff607dbdcc1e9b9af1755371f92a68f706051cc8c37d447c905",
+                "sha256:88e5fcfb52ee7b911e8bb6d6aa2fd21fbecc674eadd44118a9cc3863f938e735",
+                "sha256:8defac2f2ccd6805ebf65f5eeb132adcf2ab57aa11fdf4c0dd5169a004710e7d",
+                "sha256:98c7086708b163d425c67c7a91bad6e466bb99d797aa64f965e9d25c12111a5e",
+                "sha256:9add70b36c5666a2ed02b43b335fe19002ee5235efd4b8a89bfcf9005bebac0d",
+                "sha256:9bf40443012702a1d2070043cb6291650a0841ece432556f784f004937f0f32c",
+                "sha256:ade5e387d2ad0d7ebf59146cc00c8044acbd863725f887353a10df825fc8ae21",
+                "sha256:b00c1de48212e4cc9603895652c5c410df699856a2853135b3967591e4beebc2",
+                "sha256:b1282f8c00509d99fef04d8ba936b156d419be841854fe901d8ae224c59f0be5",
+                "sha256:b2051432115498d3562c084a49bba65d97cf251f5a331c64a12ee7e04dacc51b",
+                "sha256:ba59edeaa2fc6114428f1637ffff42da1e311e29382d81b339c1817d37ec93c6",
+                "sha256:c8716a48d94b06bb3b2524c2b77e055fb313aeb4ea620c8dd03a105574ba704f",
+                "sha256:cd5df75523866410809ca100dc9681e301e3c27567cf498077e8551b6d20e42f",
+                "sha256:e249096428b3ae81b08327a63a485ad0878de3fb939049038579ac0ef61e17e7"
+            ],
+            "version": "==1.1.1"
+        },
         "mccabe": {
             "hashes": [
                 "sha256:ab8a6258860da4b6677da4bd2fe5dc2c659cff31b3ee4f7f5d64e79735b80d42",
@@ -861,6 +929,20 @@
                 "sha256:92b8c4b06dac4f0611c0729b2f2ede52b2e1bac1ab48f089c7ddc12e26bb60c4"
             ],
             "version": "==7.2.0"
+        },
+        "oauthlib": {
+            "hashes": [
+                "sha256:bee41cc35fcca6e988463cacc3bcb8a96224f470ca547e697b604cc697b2f889",
+                "sha256:df884cd6cbe20e32633f1db1072e9356f53638e4361bef4e8b03c9127c9328ea"
+            ],
+            "version": "==3.1.0"
+        },
+        "openshift": {
+            "hashes": [
+                "sha256:e5dcee468a6b310d8d76d0238430ad2aedcbc3b57ad7259222ccf178d92f1d3b"
+            ],
+            "index": "pypi",
+            "version": "==0.10.0rc1"
         },
         "packaging": {
             "hashes": [
@@ -890,6 +972,20 @@
                 "sha256:dc639b046a6e2cff5bbe40194ad65936d6ba360b52b3c3fe1d08a82dd50b5e53"
             ],
             "version": "==1.8.0"
+        },
+        "pyasn1": {
+            "hashes": [
+                "sha256:62cdade8b5530f0b185e09855dd422bc05c0bbff6b72ff61381c09dac7befd8c",
+                "sha256:a9495356ca1d66ed197a0f72b41eb1823cf7ea8b5bd07191673e8147aecf8604"
+            ],
+            "version": "==0.4.7"
+        },
+        "pyasn1-modules": {
+            "hashes": [
+                "sha256:0c35a52e00b672f832e5846826f1fb7507907f7d52fba6faa9e3c4cbe874fe4b",
+                "sha256:b6ada4f840fe51abf5a6bd545b45bf537bea62221fa0dde2e8a553ed9f06a4e3"
+            ],
+            "version": "==0.2.7"
         },
         "pycodestyle": {
             "hashes": [
@@ -958,12 +1054,90 @@
             "index": "pypi",
             "version": "==2.8.1"
         },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
+                "sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"
+            ],
+            "markers": "python_version >= '2.7'",
+            "version": "==2.8.0"
+        },
+        "python-string-utils": {
+            "hashes": [
+                "sha256:05d24a8d884b629b534af992dc1f35dc4de4c73678ffdffa0efcbe667058af1f"
+            ],
+            "version": "==0.6.0"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:0113bc0ec2ad727182326b61326afa3d1d8280ae1122493553fd6f4397f33df9",
+                "sha256:01adf0b6c6f61bd11af6e10ca52b7d4057dd0be0343eb9283c878cf3af56aee4",
+                "sha256:5124373960b0b3f4aa7df1707e63e9f109b5263eca5976c66e08b1c552d4eaf8",
+                "sha256:5ca4f10adbddae56d824b2c09668e91219bb178a1eee1faa56af6f99f11bf696",
+                "sha256:7907be34ffa3c5a32b60b95f4d95ea25361c951383a894fec31be7252b2b6f34",
+                "sha256:7ec9b2a4ed5cad025c2278a1e6a19c011c80a3caaac804fd2d329e9cc2c287c9",
+                "sha256:87ae4c829bb25b9fe99cf71fbb2140c448f534e24c998cc60f39ae4f94396a73",
+                "sha256:9de9919becc9cc2ff03637872a440195ac4241c80536632fffeb6a1e25a74299",
+                "sha256:a5a85b10e450c66b49f98846937e8cfca1db3127a9d5d1e31ca45c3d0bef4c5b",
+                "sha256:b0997827b4f6a7c286c01c5f60384d218dca4ed7d9efa945c3e1aa623d5709ae",
+                "sha256:b631ef96d3222e62861443cc89d6563ba3eeb816eeb96b2629345ab795e53681",
+                "sha256:bf47c0607522fdbca6c9e817a6e81b08491de50f3766a7a0e6a5be7905961b41",
+                "sha256:f81025eddd0327c7d4cfe9b62cf33190e1e736cc6e97502b3ec425f574b3e7a8"
+            ],
+            "index": "pypi",
+            "version": "==5.1.2"
+        },
         "requests": {
             "hashes": [
                 "sha256:11e007a8a2aa0323f5a921e9e6a2d7e4e67d9877e85773fba9ba6419025cbeb4",
                 "sha256:9cf5292fcd0f598c671cfc1e0d7d1a7f13bb8085e9a590f48c010551dc6c4b31"
             ],
             "version": "==2.22.0"
+        },
+        "requests-oauthlib": {
+            "hashes": [
+                "sha256:bd6533330e8748e94bf0b214775fed487d309b8b8fe823dc45641ebcd9a32f57",
+                "sha256:d3ed0c8f2e3bbc6b344fa63d6f933745ab394469da38db16bdddb461c7e25140"
+            ],
+            "version": "==1.2.0"
+        },
+        "rsa": {
+            "hashes": [
+                "sha256:14ba45700ff1ec9eeb206a2ce76b32814958a98e372006c8fb76ba820211be66",
+                "sha256:1a836406405730121ae9823e19c6e806c62bbad73f890574fff50efa4122c487"
+            ],
+            "version": "==4.0"
+        },
+        "ruamel.yaml": {
+            "hashes": [
+                "sha256:0db639b1b2742dae666c6fc009b8d1931ef15c9276ef31c0673cc6dcf766cf40",
+                "sha256:412a6f5cfdc0525dee6a27c08f5415c7fd832a7afcb7a0ed7319628aed23d408"
+            ],
+            "version": "==0.16.5"
+        },
+        "ruamel.yaml.clib": {
+            "hashes": [
+                "sha256:1e77424825caba5553bbade750cec2277ef130647d685c2b38f68bc03453bac6",
+                "sha256:392b7c371312abf27fb549ec2d5e0092f7ef6e6c9f767bfb13e83cb903aca0fd",
+                "sha256:4d55386129291b96483edcb93b381470f7cd69f97585829b048a3d758d31210a",
+                "sha256:550168c02d8de52ee58c3d8a8193d5a8a9491a5e7b2462d27ac5bf63717574c9",
+                "sha256:57933a6986a3036257ad7bf283529e7c19c2810ff24c86f4a0cfeb49d2099919",
+                "sha256:615b0396a7fad02d1f9a0dcf9f01202bf9caefee6265198f252c865f4227fcc6",
+                "sha256:77556a7aa190be9a2bd83b7ee075d3df5f3c5016d395613671487e79b082d784",
+                "sha256:7aee724e1ff424757b5bd8f6c5bbdb033a570b2b4683b17ace4dbe61a99a657b",
+                "sha256:8073c8b92b06b572e4057b583c3d01674ceaf32167801fe545a087d7a1e8bf52",
+                "sha256:9c6d040d0396c28d3eaaa6cb20152cb3b2f15adf35a0304f4f40a3cf9f1d2448",
+                "sha256:a0ff786d2a7dbe55f9544b3f6ebbcc495d7e730df92a08434604f6f470b899c5",
+                "sha256:b1b7fcee6aedcdc7e62c3a73f238b3d080c7ba6650cd808bce8d7761ec484070",
+                "sha256:b66832ea8077d9b3f6e311c4a53d06273db5dc2db6e8a908550f3c14d67e718c",
+                "sha256:d0d3ac228c9bbab08134b4004d748cf9f8743504875b3603b3afbb97e3472947",
+                "sha256:d10e9dd744cf85c219bf747c75194b624cc7a94f0c80ead624b06bfa9f61d3bc",
+                "sha256:ea4362548ee0cbc266949d8a441238d9ad3600ca9910c3fe4e82ee3a50706973",
+                "sha256:ed5b3698a2bb241b7f5cbbe277eaa7fe48b07a58784fba4f75224fd066d253ad",
+                "sha256:f9dcc1ae73f36e8059589b601e8e4776b9976effd76c21ad6a855a74318efd6e"
+            ],
+            "markers": "platform_python_implementation == 'CPython' and python_version < '3.8'",
+            "version": "==0.2.0"
         },
         "sarge": {
             "hashes": [
@@ -1052,6 +1226,13 @@
                 "sha256:f4ebe71925af7b40a864553f761ed559b43544f8f71746c2d756c7fe788ade7c"
             ],
             "version": "==0.1.7"
+        },
+        "websocket-client": {
+            "hashes": [
+                "sha256:1151d5fb3a62dc129164292e1227655e4bbc5dd5340a5165dfae61128ec50aa9",
+                "sha256:1fd5520878b68b84b5748bb30e592b10d0a91529d5383f74f4964e72b297fd3a"
+            ],
+            "version": "==0.56.0"
         },
         "wrapt": {
             "hashes": [

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [aliases]
 test=pytest
+
+[tool:pytest]
+addopts=--ignore=./tests/e2e

--- a/tests/e2e/Makefile
+++ b/tests/e2e/Makefile
@@ -1,0 +1,18 @@
+.SILENT: help
+
+help:
+	echo "Use this make file to use pre-configured config files for fast use."
+	echo "make [runtests | clean] ARGS "
+	echo
+	echo "ARGS:"
+	echo "host		OCP host, format must be <host>:<port> e.g. localhost:8443"
+	echo "auth		OCP Auth Token"
+	echo "namespace OCP namespace to run tests in"
+
+e2e-tests-run:
+	sed -e 's/<host>/$(host)/g' -e 's/<auth_token>/$(auth)/g' -e 's/<namespace>/$(namespace)/g' configs/fulltest.yaml > config.yaml
+	pipenv run pytest test_openshift_deployments.py --pytest_config=config.yaml
+
+e2e-tests-clean:
+	sed -e 's/<host>/$(host)/g' -e 's/<auth_token>/$(auth)/g' -e 's/<namespace>/$(namespace)/g' configs/cleanup.yaml > config.yaml
+	pipenv run pytest test_openshift_deployments.py --pytest_config=config.yaml

--- a/tests/e2e/__init__.py
+++ b/tests/e2e/__init__.py
@@ -1,0 +1,1 @@
+"""Test : Integrations tests for openshift."""

--- a/tests/e2e/configs/cleanup.yaml
+++ b/tests/e2e/configs/cleanup.yaml
@@ -1,0 +1,43 @@
+openshift:
+  # The ocp name space to test in
+  namespace: <namespace>
+  # The ocp auth token
+  authToken: <auth_token>
+  # The ocp host e.g: localhost:8443
+  host: <host>
+  # Delete objects from ocp namespace created by the openshift templates in this
+  # repo. Note that this clean up will execute even if all "deploy"
+  # and "runtests" are disabled.
+  clean: "True"
+  # The amount of minutes to wait for resources to reach success phases
+  timeout: 10
+logs:
+  # The logs file name prefix
+  build_log_file: ./logs/e2e_build_logs
+  pod_log_file: ./logs/e2e_pod_logs
+spec:
+  factstore:
+    deploy: "False"
+    runtests: "False"
+    template: ../../openshift/aiops_factstore.deployment.yaml
+    timeout: 10
+  ad_demo:
+    deploy: "False"
+    runtests: "False"
+    template: https://raw.githubusercontent.com/AICoE/anomaly-detection-demo-app/master/openshift/ad_demo.yaml
+    timeout: 10
+  elasticsearch:
+    deploy: "False"
+    runtests: "False"
+    template: ../../openshift/aiops_lad_core.elasticsearch.storage.yaml
+    timeout: 10
+  mysql:
+    deploy: "False"
+    runtests: "False"
+    template: ../../openshift/databases/mysql-persistent.yaml
+    timeout: 10
+  lad:
+    deploy: "False"
+    runtests: "False"
+    template: ../../openshift/log-anomaly-detector-minishift.yaml
+    timeout: 10

--- a/tests/e2e/configs/fulltest.yaml
+++ b/tests/e2e/configs/fulltest.yaml
@@ -1,0 +1,43 @@
+openshift:
+  # The ocp name space to test in
+  namespace: <namespace>
+  # The ocp auth token
+  authToken: <auth_token>
+  # The ocp host e.g: localhost:8443
+  host: <host>
+  # Delete objects from ocp namespace created by the openshift templates in this
+  # repo. Note that this clean up will execute even if all "deploy"
+  # and "runtests" are disabled.
+  clean: "False"
+  # The amount of minutes to wait for resources to reach success phases
+  timeout: 10
+logs:
+  # The logs file name prefix
+  build_log_file: ./logs/e2e_build_logs
+  pod_log_file: ./logs/e2e_pod_logs
+spec:
+  factstore:
+    deploy: "True"
+    runtests: "True"
+    template: ../../openshift/aiops_factstore.deployment.yaml
+    timeout: 10
+  ad_demo:
+    deploy: "True"
+    runtests: "True"
+    template: https://raw.githubusercontent.com/AICoE/anomaly-detection-demo-app/master/openshift/ad_demo.yaml
+    timeout: 10
+  elasticsearch:
+    deploy: "True"
+    runtests: "True"
+    template: ../../openshift/aiops_lad_core.elasticsearch.storage.yaml
+    timeout: 10
+  mysql:
+    deploy: "True"
+    runtests: "True"
+    template: ../../openshift/databases/mysql-persistent.yaml
+    timeout: 10
+  lad:
+    deploy: "True"
+    runtests: "True"
+    template: ../../openshift/log-anomaly-detector-minishift.yaml
+    timeout: 10

--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -1,0 +1,212 @@
+"""Pytest Configurations and Fixtures."""
+from tests.e2e.util import OpenShift, template_deployer, delete_template, \
+    delete_objects
+import pytest
+from kubernetes import client as kubeclient
+from openshift.dynamic import DynamicClient
+import yaml
+from openshift.dynamic.exceptions import UnauthorizedError
+import logging
+from os import path, makedirs
+
+
+class Spec:
+    """Spec config constants."""
+
+    FACTSTORE = "factstore"
+    AD_DEMO = "ad_demo"
+    ELASTICSEARCH = "elasticsearch"
+    MYSQL = "mysql"
+    LAD = "lad"
+
+
+MY_SQL_CONF = {
+    "MYSQL_USER": "admin",
+    "MYSQL_PASSWORD": "admin",
+    "MYSQL_ROOT_PASSWORD": "admin",
+    "MYSQL_DATABASE": "factstore"
+}
+
+DB_URI = "mysql+pymysql://{}:{}@{}/{}".format(
+    MY_SQL_CONF['MYSQL_USER'],
+    MY_SQL_CONF['MYSQL_PASSWORD'],
+    "mysql:3306",
+    MY_SQL_CONF['MYSQL_DATABASE']
+)
+
+
+logger = logging.getLogger('chardet.charsetprober')
+logger.setLevel(logging.INFO)
+
+
+def pytest_addoption(parser):
+    """Update pytest options."""
+    parser.addoption("--pytest_config",
+                     action="store",
+                     default="config.yaml",
+                     help="pytest yaml config name")
+
+
+def pytest_configure(config):
+    """Configure pytest."""
+    value = config.getini("log_file")
+    pytest_yml_config = config.getoption("--pytest_config")
+
+    directory = path.dirname(value)
+    if not path.exists(directory):
+        makedirs(directory)
+    with open(pytest_yml_config, 'r') as stream:
+        config_def = yaml.safe_load(stream)
+    value = config_def['logs']['build_log_file']
+    directory = path.dirname(value)
+    if not path.exists(directory):
+        makedirs(directory)
+
+
+@pytest.fixture(scope="session")
+def config(request) -> dict:
+    """Return the pytest yaml config."""
+    with open(request.config.getoption("--pytest_config"), 'r') as stream:
+        config_def = yaml.safe_load(stream)
+    return config_def
+
+
+@pytest.fixture(scope="session")
+def openshift(config: dict):
+    """Provide openshift instance."""
+    token = config['openshift']['authToken']
+    host = config['openshift']['host']
+    namespace = config['openshift']['namespace']
+
+    configuration = kubeclient.Configuration()
+
+    token_auth = dict(
+        api_key={'authorization': 'Bearer {}'.format(token)},
+        host='https://{}'.format(host),
+        verify_ssl=False
+    )
+
+    for k, v in token_auth.items():
+        setattr(configuration, k, v)
+
+    kubeclient.Configuration.set_default(configuration)
+
+    k8s_client = kubeclient.ApiClient(configuration)
+    client = None
+    try:
+        client = DynamicClient(k8s_client)
+    except UnauthorizedError:
+        logging.error("Token is not authorized. Please supply another token.")
+        exit(1)
+    except Exception:
+        logging.error("Could not connect to openshift cluster, "
+                      "please ensure host settings are accurate.")
+
+    ocp_url = "https://{}".format(host)
+
+    openshift = OpenShift(
+        namespace=namespace,
+        openshift_api_url=ocp_url,
+        token=token,
+        client=client
+    )
+
+    openshift.create_project()
+
+    # The fixture return value
+    return openshift
+
+
+@pytest.fixture(scope="session")
+def mysql_persistent(openshift: OpenShift, config: dict) -> list:
+    """Provide deployed mysql_persistent objects."""
+    mysql_persistent = template_deployer(
+        openshift=openshift, spec=Spec.MYSQL, config=config, **MY_SQL_CONF
+    )
+    yield mysql_persistent
+    if config['openshift']['clean'].lower() == "true":
+        delete_objects(openshift, config, Spec.MYSQL, **MY_SQL_CONF)
+        delete_template(openshift, config, Spec.MYSQL)
+
+
+@pytest.fixture(scope="session")
+def factstore(openshift: OpenShift, config: dict):
+    """Provide deployed factstore objects."""
+    factstore = template_deployer(
+        openshift=openshift,
+        spec=Spec.FACTSTORE,
+        config=config,
+        CUSTOMER_ID="c1",
+        SQL_CONNECT=DB_URI
+    )
+    yield factstore
+    if config['openshift']['clean'].lower() == "true":
+        delete_objects(openshift, config, Spec.FACTSTORE,
+                       CUSTOMER_ID="c1", SQL_CONNECT=DB_URI)
+        delete_template(openshift, config, Spec.FACTSTORE)
+
+
+@pytest.fixture(scope="session")
+def elasticsearch(openshift: OpenShift, config: dict) -> list:
+    """Provide deployed elasticsearch objects."""
+    elasticsearch = template_deployer(
+        openshift=openshift,
+        spec=Spec.ELASTICSEARCH,
+        config=config
+    )
+    yield elasticsearch
+    if config['openshift']['clean'].lower() == "true":
+        delete_objects(openshift, config, Spec.ELASTICSEARCH)
+        delete_template(openshift, config, Spec.ELASTICSEARCH)
+
+
+@pytest.fixture(scope="session")
+def ad_demo(openshift: OpenShift, config: dict) -> list:
+    """Provide deployed ad_demo objects."""
+    ad_demo = template_deployer(
+        openshift=openshift,
+        spec=Spec.AD_DEMO,
+        config=config
+    )
+    yield ad_demo
+    if config['openshift']['clean'].lower() == "true":
+        delete_objects(openshift, config, Spec.AD_DEMO)
+        delete_template(openshift, config, Spec.AD_DEMO)
+
+
+@pytest.fixture(scope="session")
+def lad(openshift: OpenShift, config: dict, factstore: list) -> list:
+    """Provide deployed lad objects."""
+    es_endpoint = "lad-elasticsearch-service.{}.svc:9200".format(
+        openshift.namespace
+    )
+
+    if not factstore:
+        host = "no-host"
+    else:
+        resources = openshift.extract_resource_from_response(
+            resp=factstore,
+            kind="Route",
+        )
+        template_route = resources.pop()
+        route_name = template_route['metadata']['name']
+        try:
+            oc_fs_route = openshift.get_route_by_name(route_name)
+            host = oc_fs_route['spec']['host']
+        except Exception as e:
+            logging.warning("Could not retrieve factstore route.")
+            host = "no-host"
+    factstore_url = "http://{}".format(host)
+
+    lad = template_deployer(openshift=openshift,
+                            spec=Spec.LAD,
+                            config=config,
+                            FACT_STORE_URL=factstore_url,
+                            ES_ENDPOINT=es_endpoint)
+
+    yield lad
+    if config['openshift']['clean'].lower() == "true":
+        delete_objects(openshift, config, Spec.LAD,
+                       FACT_STORE_URL=factstore_url,
+                       ES_ENDPOINT=es_endpoint)
+        delete_template(openshift, config, Spec.LAD)

--- a/tests/e2e/pytest.ini
+++ b/tests/e2e/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+filterwarnings = ignore::urllib3.exceptions.InsecureRequestWarning
+log_file=./logs/test_logs
+log_file_level=INFO
+log_cli=true
+tb=short

--- a/tests/e2e/test_openshift_deployments.py
+++ b/tests/e2e/test_openshift_deployments.py
@@ -1,0 +1,321 @@
+"""Openshift Tests."""
+import requests
+from tests.e2e.conftest import Spec
+from tests.e2e.util import OpenShift, wait_for_condition, deployment_running, \
+    build_finished_successfully, container_running, check_skip_test
+
+
+def test_mysql_deployment(openshift: OpenShift, mysql_persistent: list,
+                          config: dict):
+    """Test MySQL Deployment."""
+    check_skip_test(
+        config=config,
+        spec=Spec.MYSQL,
+        test_name=test_mysql_deployment.__name__
+    )
+    # Ensure we successfully deployed (if indicated) or retrieved template.
+    assert len(mysql_persistent) > 0
+
+    timeout = config['spec'][Spec.MYSQL]['timeout']
+    resources = openshift.extract_resource_from_response(
+        resp=mysql_persistent,
+        kind="DeploymentConfig",
+    )
+    deploy_cfg = resources.pop()
+    is_running = deployment_running(openshift, deploy_cfg, timeout)
+    assert is_running
+
+
+def test_fact_store_build(openshift: OpenShift, factstore: list, config: dict):
+    """Test factstore build."""
+    check_skip_test(
+        config=config,
+        spec=Spec.FACTSTORE,
+        test_name=test_fact_store_build.__name__
+    )
+    # Ensure we successfully deployed (if indicated) or retrieved template.
+    assert len(factstore) > 0
+
+    timeout_amount = config['spec'][Spec.FACTSTORE]['timeout']
+    build_log_file = config['logs']["build_log_file"]
+
+    resources = openshift.extract_resource_from_response(
+        resp=factstore,
+        kind="BuildConfig",
+    )
+    build_cfg = resources.pop()
+
+    build_sucessfully_completed = build_finished_successfully(
+        openshift, build_cfg, timeout_amount, build_log_file
+    )
+
+    assert build_sucessfully_completed
+
+
+def test_fact_store_deployment(openshift: OpenShift,
+                               factstore: list,
+                               config: dict):
+    """Test factstore deployment."""
+    check_skip_test(
+        config=config,
+        spec=Spec.FACTSTORE,
+        test_name=test_fact_store_deployment.__name__
+    )
+    # Ensure we successfully deployed (if indicated) or retrieved template.
+    assert len(factstore) > 0
+
+    timeout_amount = config['spec'][Spec.FACTSTORE]['timeout']
+    resources = openshift.extract_resource_from_response(
+        resp=factstore,
+        kind="DeploymentConfig",
+    )
+    deploy_cfg = resources.pop()
+    is_running = deployment_running(openshift, deploy_cfg, timeout_amount)
+    assert is_running
+
+
+def test_fact_store_route_health(openshift: OpenShift, factstore: list,
+                                 config: dict):
+    """Test Facstore route."""
+    check_skip_test(
+        config=config,
+        spec=Spec.FACTSTORE,
+        test_name=test_fact_store_route_health.__name__
+    )
+    # Ensure we successfully deployed (if indicated) or retrieved template.
+    assert len(factstore) > 0
+
+    timeout = config['spec'][Spec.FACTSTORE]['timeout']
+    resources = openshift.extract_resource_from_response(
+        resp=factstore,
+        kind="Route",
+    )
+    template_route = resources.pop()
+    route_name = template_route['metadata']['name']
+
+    route_is_healthy = wait_for_condition(
+        success_cond=lambda: openshift.get_route_status_code(route_name) == 200,
+        min_to_wait=timeout
+    )
+
+    assert route_is_healthy
+
+    db_route_connection_is_healthy = wait_for_condition(
+        success_cond=lambda: openshift.get_route_status_code(
+            route_name,
+            path_suffix='/api/false_positive'
+        ) == 200,
+        min_to_wait=timeout
+    )
+
+    assert db_route_connection_is_healthy
+
+
+def test_es_deployment(openshift: OpenShift, elasticsearch: list,
+                       config: dict):
+    """Test Elastic Search Deployment."""
+    check_skip_test(
+        config=config,
+        spec=Spec.ELASTICSEARCH,
+        test_name=test_es_deployment.__name__
+    )
+    # Ensure we successfully deployed (if indicated) or retrieved template.
+    assert len(elasticsearch) > 0
+    timeout = config['spec'][Spec.ELASTICSEARCH]['timeout']
+    resources = openshift.extract_resource_from_response(
+        resp=elasticsearch,
+        kind="DeploymentConfig",
+    )
+    deploy_cfg = resources.pop()
+    is_running = deployment_running(openshift, deploy_cfg, timeout)
+    assert is_running
+
+
+def test_ad_demo_build(openshift: OpenShift, ad_demo: list, config: dict):
+    """Test Anomaly Detection Demo Build."""
+    check_skip_test(
+        config=config,
+        spec=Spec.AD_DEMO,
+        test_name=test_ad_demo_build.__name__
+    )
+    # Ensure we successfully deployed (if indicated) or retrieved template.
+    assert len(ad_demo) > 0
+
+    timeout = config['spec'][Spec.AD_DEMO]['timeout']
+    build_log_file = config['logs']["build_log_file"]
+    resources = openshift.extract_resource_from_response(
+        resp=ad_demo,
+        kind="BuildConfig",
+    )
+    build_cfg = resources.pop()
+
+    build_sucessfully_completed = build_finished_successfully(
+        openshift, build_cfg, timeout, build_log_file
+    )
+
+    assert build_sucessfully_completed
+
+
+def test_ad_demo_deployment(openshift: OpenShift, ad_demo: list, config: dict):
+    """Test Anomaly Detection Demo Deployment."""
+    check_skip_test(
+        config=config,
+        spec=Spec.AD_DEMO,
+        test_name=test_ad_demo_deployment.__name__
+    )
+    # Ensure we successfully deployed (if indicated) or retrieved template.
+    assert len(ad_demo) > 0
+    timeout = config['spec'][Spec.AD_DEMO]['timeout']
+    resources = openshift.extract_resource_from_response(
+        resp=ad_demo,
+        kind="DeploymentConfig",
+    )
+    deploy_cfg = resources.pop()
+    is_running = deployment_running(openshift, deploy_cfg, timeout)
+    assert is_running
+
+
+def test_ad_demo_container_started(openshift: OpenShift,
+                                   ad_demo: list, config: dict):
+    """Test Anomaly Detection Demo container status."""
+    check_skip_test(
+        config=config,
+        spec=Spec.AD_DEMO,
+        test_name=test_ad_demo_container_started.__name__
+    )
+    # Ensure we successfully deployed (if indicated) or retrieved template.
+    assert len(ad_demo) > 0
+    timeout = config['spec'][Spec.AD_DEMO]['timeout']
+    resources = openshift.extract_resource_from_response(
+        resp=ad_demo,
+        kind="DeploymentConfig",
+    )
+
+    deploy_cfg = resources.pop()
+    is_running = container_running(
+        openshift=openshift,
+        deploy_cfg=deploy_cfg,
+        timeout_amount=timeout,
+        container_id=0,
+        pod_log_file_prefix=config['logs']['pod_log_file']
+    )
+    assert is_running
+
+
+def test_ad_demo_route_health(openshift: OpenShift,
+                              ad_demo: list, config: dict):
+    """Test Anomaly Detection Demo Route Health."""
+    check_skip_test(
+        config=config,
+        spec=Spec.AD_DEMO,
+        test_name=test_ad_demo_route_health.__name__
+    )
+    # Ensure we successfully deployed (if indicated) or retrieved template.
+    assert len(ad_demo) > 0
+    timeout = config['spec'][Spec.AD_DEMO]['timeout']
+    resources = openshift.extract_resource_from_response(
+        resp=ad_demo,
+        kind="Route",
+    )
+
+    resources = list(filter(
+        lambda route: not route['metadata']['name'].endswith('metrics'),
+        resources
+    ))
+    template_route = resources.pop()
+    route_name = template_route['metadata']['name']
+
+    is_healthy = wait_for_condition(
+        success_cond=lambda: openshift.get_route_status_code(route_name) == 200,
+        min_to_wait=timeout
+    )
+    assert is_healthy
+
+
+def test_ad_demo_order_placement(openshift: OpenShift,
+                                 ad_demo: list, config: dict):
+    """Test Anomaly Detection Demo Order Placement."""
+    check_skip_test(
+        config=config,
+        spec=Spec.AD_DEMO,
+        test_name=test_ad_demo_order_placement.__name__
+    )
+    # Ensure we successfully deployed (if indicated) or retrieved template.
+    assert len(ad_demo) > 0
+    resources = openshift.extract_resource_from_response(
+        resp=ad_demo,
+        kind="Route",
+    )
+    resources = list(filter(
+        lambda route: not route['metadata']['name'].endswith('metrics'),
+        resources
+    ))
+    template_route = resources.pop()
+    route_name = template_route['metadata']['name']
+    route = openshift.get_route_by_name(route_name)
+    route_url = "http://{}/mock/orderService".format(route['spec']['host'])
+    form_data = {
+        "79161a98-30e0-11e7-b4e8-9801a798fc8f[id]": "1",
+        "79161a98-30e0-11e7-b4e8-9801a798fc8f[image]": "bananas.jpg",
+        "79161a98-30e0-11e7-b4e8-9801a798fc8f[pname]": "bananas",
+        "79161a98-30e0-11e7-b4e8-9801a798fc8f[pprice]": "5",
+        "79161a98-30e0-11e7-b4e8-9801a798fc8f[pquant]": "1",
+        "79161a98-30e0-11e7-b4e8-9801a798fc8f[ptype]": "fruit",
+        "79161a98-30e0-11e7-b4e8-9801a798fc8f[newQuant]": "1",
+        "7915f0cc-30e0-11e7-91c7-9801a798fc8f[id]": "2",
+        "7915f0cc-30e0-11e7-91c7-9801a798fc8f[image]": "onions.jpg",
+        "7915f0cc-30e0-11e7-91c7-9801a798fc8f[pname]": "onions",
+        "7915f0cc-30e0-11e7-91c7-9801a798fc8f[pprice]": "3",
+        "7915f0cc-30e0-11e7-91c7-9801a798fc8f[pquant]": "1",
+        "7915f0cc-30e0-11e7-91c7-9801a798fc8f[ptype]": "vegetables",
+        "7915f0cc-30e0-11e7-91c7-9801a798fc8f[newQuant]": "1"
+    }
+    with requests.Session() as s:
+        s.headers = {"User-Agent": "Mozilla/5.0"}
+        res = s.post(route_url, data=form_data)
+    assert res.status_code == 200
+
+
+def test_lad_deployment(openshift: OpenShift, lad: list, config: dict):
+    """Test Lad Deployment."""
+    check_skip_test(
+        config=config,
+        spec=Spec.LAD,
+        test_name=test_lad_deployment.__name__
+    )
+    # Ensure we successfully deployed (if indicated) or retrieved template.
+    assert len(lad) > 0
+    timeout = config['spec'][Spec.LAD]['timeout']
+    resources = openshift.extract_resource_from_response(
+        resp=lad,
+        kind="DeploymentConfig",
+    )
+    deploy_cfg = resources.pop()
+    is_running = deployment_running(openshift, deploy_cfg, timeout)
+    assert is_running
+
+
+def test_lad_container_started(openshift: OpenShift, lad: list, config: dict):
+    """Test Lad container status."""
+    check_skip_test(
+        config=config,
+        spec=Spec.LAD,
+        test_name=test_lad_container_started.__name__
+    )
+    # Ensure we successfully deployed (if indicated) or retrieved template.
+    assert len(lad) > 0
+    timeout = config['spec'][Spec.LAD]['timeout']
+    resources = openshift.extract_resource_from_response(
+        resp=lad,
+        kind="DeploymentConfig",
+    )
+
+    deploy_cfg = resources.pop()
+    is_running = container_running(
+        openshift=openshift,
+        deploy_cfg=deploy_cfg,
+        timeout_amount=timeout,
+        container_id=0,
+        pod_log_file_prefix=config['logs']['pod_log_file']
+    )
+    assert is_running

--- a/tests/e2e/util.py
+++ b/tests/e2e/util.py
@@ -1,0 +1,755 @@
+"""Openshift Testing Utility."""
+import time
+from typing import Callable, Optional
+import pytest
+import requests
+from openshift.dynamic import exceptions, DynamicClient, ResourceInstance, \
+    ResourceField
+import yaml
+import logging
+from urllib import request as url_request
+from openshift.dynamic.exceptions import NotFoundError, ConflictError
+
+
+class OpenShift:
+    """Interaction with OpenShift within a project."""
+
+    def __init__(self,
+                 *,
+                 namespace: str = None,
+                 kubernetes_verify_tls: bool = False,
+                 openshift_api_url: str = None,
+                 token: str = None,
+                 client: DynamicClient = None
+                 ):
+        """Initialize Openshift with an associated work namespace."""
+        self.namespace = namespace
+        self.kubernetes_verify_tls = kubernetes_verify_tls
+        self.openshift_api_url = openshift_api_url
+        self.token = token
+        self.client = client
+        self.projects_resource = None
+
+    def _get_template(self, name: str) -> dict:
+        """Get template from namespace."""
+        response = self.client.resources.get(
+            api_version="template.openshift.io/v1",
+            kind="Template",
+            singular_name='template'
+        ).get(
+            namespace=self.namespace,
+            name=name
+        )
+        logging.debug(
+            "OpenShift response for getting template by label_selector %r: %r",
+            name,
+            response.to_dict(),
+        )
+        return response.to_dict()
+
+    def _get_resource(self, resource: dict) -> dict:
+        """Get resource from namespace."""
+        name = resource['metadata']['name']
+        api_version = resource['apiVersion']
+        kind = resource['kind']
+
+        v1_resource = self.client.resources.get(api_version=api_version,
+                                                kind=kind)
+        return v1_resource.get(name=name, namespace=self.namespace)
+
+    def _get_kind_res_instance(self, kind) -> ResourceInstance:
+        """Get all ResourceInstance of this kind from this namespace."""
+        return self.client.resources.get(
+            api_version='v1',
+            kind=kind
+        ).get(namespace=self.namespace)
+
+    def get_builds_by_buildconfig(self, build_config: dict) -> list:
+        """Retrieve builds that were configured by build_config."""
+        builds = self._get_kind_res_instance("Build").items
+        bfg_name = build_config['metadata']['name']
+
+        filtered_builds = []
+        for build in builds:
+            annotations = build['metadata']['annotations']
+            if annotations['openshift.io/build-config.name'] == bfg_name:
+                filtered_builds.append(build)
+        return filtered_builds
+
+    def get_pods(self) -> list:
+        """Get pod resources from this namespace."""
+        return self._get_kind_res_instance('Pod').items
+
+    def get_pods_by_deployment_cfg(self, config: dict):
+        """Return pods configured by config, ignore deployer pods."""
+        pods = self.get_pods()
+        filtered_pods = []
+        cfg_name = config['metadata']['name']
+
+        for pod in pods:
+            annotations = pod['metadata']['annotations']
+            annotation_keys = annotations.keys()
+            annotation_cfg = "openshift.io/deployment-config.name"
+            # Ignore deployer pods:
+            is_deployer_pod = pod['metadata']['name'].endswith("deploy")
+            if annotation_cfg in annotation_keys \
+                    and annotations[annotation_cfg] == cfg_name\
+                    and not is_deployer_pod:
+                filtered_pods.append(pod)
+        return filtered_pods
+
+    def get_route_by_name(self, name: str):
+        """Get a route by <name>."""
+        routes = self._get_kind_res_instance("Route")['items']
+        routes = list(filter(
+            lambda route: route['metadata']['name'] == name,
+            routes
+        ))
+
+        return routes.pop()
+
+    def get_route_status_code(self, route_name: str, path_suffix: str = ''):
+        """Get a route status code for route <name>."""
+        oc_fs_route = self.get_route_by_name(route_name)
+        host = oc_fs_route['spec']['host']
+        if path_suffix:
+            r = requests.head("http://{}{}".format(host, path_suffix))
+        else:
+            r = requests.head("http://{}".format(host))
+        return r.status_code
+
+    def is_build_complete(self, build_cfg: dict) -> bool:
+        """
+        Check if Build is complete.
+
+        Finds build configured by build_cfg and returns True if
+        all builds are complete.
+
+        Precondition: Assumes there is only one build configured by build_cfg.
+        If there are multiple builds associated with build_cfg, return first
+        one found.
+        """
+        # TODO: Consider changing to verifying all existing builds and checking
+        # if one is complete
+        all_success = []
+        builds = self.get_builds_by_buildconfig(build_cfg)
+        for build in builds:
+            name = build['metadata']['name']
+            phase = build['status']['phase']
+            logging.debug("Checking build {} for completion, has phase:{}".format(
+                name, phase))
+            if phase == 'Complete':
+                all_success.append(True)
+            else:
+                all_success.append(False)
+        return all_success != [] and all(all_success)
+
+    def is_build_failed(self, build_cfg: dict) -> bool:
+        """
+        Check if build failed.
+
+        Finds build configured by build_cfg and returns True if
+        build failed.
+
+        Precondition: Assumes there is only one build configured by build_cfg.
+        If there are multiple builds associated with build_cfg, return first
+        one found.
+        """
+        builds = self.get_builds_by_buildconfig(build_cfg)
+        any_fails = []
+        for build in builds:
+            name = build['metadata']['name']
+            phase = build['status']['phase']
+            logging.debug("Checking build {} for errors, has phase:{}".format(
+                name, phase))
+            failed = phase == 'Failed'
+            error = phase == 'Error'
+            cancelled = phase == 'Cancelled'
+            if failed or error or cancelled:
+                any_fails.append(True)
+        return any_fails != []
+
+    def get_build_log(self, build_id: str) -> str:
+        """Get log of a build in the given namespace."""
+        endpoint = "{}/apis/build.openshift.io/v1/namespaces/{}/builds/{}/log"\
+            .format(self.openshift_api_url, self.namespace, build_id)
+
+        response = requests.get(
+            endpoint,
+            headers={
+                "Authorization": "Bearer {}".format(self.token),
+                "Content-Type": "application/json",
+            },
+            verify=self.kubernetes_verify_tls,
+        )
+
+        if response.status_code == 404:
+            raise Exception(
+                f"Build with id {build_id} was not found in "
+                f"namespace {self.namespace}"
+            )
+
+        logging.debug(
+            "OpenShift response for build log (%d): %r",
+            response.status_code,
+            response.text,
+        )
+        response.raise_for_status()
+
+        return response.text
+
+    def get_pod_log(self, pod_id: str) -> Optional[str]:
+        """Get log of a pod based on assigned pod ID."""
+        endpoint = "{}/api/v1/namespaces/{}/pods/{}/log".format(
+            self.openshift_api_url, self.namespace, pod_id
+        )
+        response = requests.get(
+            endpoint,
+            headers={
+                "Authorization": "Bearer {}".format(self.token),
+                "Content-Type": "application/json",
+            },
+            verify=self.kubernetes_verify_tls,
+        )
+        logging.debug(
+            "Kubernetes master response for pod log (%d): %r",
+            response.status_code,
+            response.text,
+        )
+
+        if response.status_code == 404:
+            raise Exception(
+                f"Pod with id {pod_id} was not found in "
+                f"namespace {self.namespace}"
+            )
+
+        if response.status_code == 400:
+            # If Pod has not been initialized yet, there is returned 400
+            # status code. Return None in this case.
+            return None
+
+        response.raise_for_status()
+        return response.text
+
+    @staticmethod
+    def pods_running(pods: list):
+        """Return true if all pods are in running phase."""
+        all_running = []
+        for pod in pods:
+            if pod['status']['phase'] == 'Running':
+                logging.debug("Found pod {} to be in running phase.".format(
+                    pod['metadata']['name']
+                ))
+                all_running.append(True)
+            else:
+                all_running.append(False)
+        return all_running != [] and all(all_running)
+
+    @staticmethod
+    def pods_failed(pods: list):
+        """Check if any pod in <pods> has faild."""
+        all_running = []
+        for pod in pods:
+            phase = pod['status']['phase']
+            if phase == 'Failed' or phase == 'Unknown':
+                logging.debug("Found pod {} to be in {} phase.".format(
+                    pod['metadata']['name'], phase))
+                all_running.append(True)
+        return all_running != []
+
+    def containers_are_running(self, container_id: int, pods: list):
+        """Check if containers with <container_id> in <pods> are running."""
+        containers_running = []
+        for pod in pods:
+            if self.container_is_running(
+                    container_id=container_id,
+                    pod=pod):
+                containers_running.append(True)
+            else:
+                containers_running.append(False)
+        return containers_running != [] and all(containers_running)
+
+    def containers_are_failing(self, container_id: int, pods: list):
+        """Return True if any <container_id> in <pods> are in fail state."""
+        containers_running = []
+        for pod in pods:
+            if self.container_stuck_or_terminated(
+                    container_id=container_id,
+                    pod=pod):
+                containers_running.append(True)
+        return containers_running != []
+
+    @staticmethod
+    def container_is_running(container_id: int, pod: ResourceField) -> bool:
+        """
+        Check if container is running.
+
+        Check if a particular container indexed at <container_id> is
+        running in <pod>.
+        """
+        container_status = pod['status']['containerStatuses'][container_id]
+        if 'running' in container_status['state'].keys():
+            logging.info(
+                "Container [id: {}] with name {} started at {}.".format(
+                    container_status['containerID'],
+                    container_status['name'],
+                    container_status['state']['running']['startedAt']
+                ))
+            return True
+        else:
+            return False
+
+    @staticmethod
+    def container_stuck_or_terminated(container_id: int,
+                                      pod: ResourceField) -> bool:
+        """
+        Check if container is stuck or terminated.
+
+        Check if container indexed at <container_id> in <pod> has
+        terminated or is stuck, return True if it has.
+        """
+        container_status = pod['status']['containerStatuses'][container_id]
+        if 'waiting' in container_status['state'].keys():
+            reason = container_status['state']['waiting']['reason']
+            if reason == 'CrashLoopBackOff':
+                logging.error("Container [id: {}] with name {} is "
+                              "Crashlooping.".format(
+                               container_status['containerID'],
+                               container_status['name']))
+                return True
+            return False
+        elif 'terminated' in container_status['state'].keys():
+            reason = container_status['state']['terminated']['reason']
+            logging.error("Container [id: {}] with name {} Terminated."
+                          "Reason: {}".format(
+                           container_status['containerID'],
+                           container_status['name'],
+                           reason))
+            return True
+        else:
+            return False
+
+    def create_project(self):
+        """
+        Create a project in this namespace.
+
+        If the project already exists, do nothing.
+        """
+        try:
+            self.projects_resource = self.client.resources.get(
+                api_version='project.openshift.io/v1',
+                kind='Project'
+            )
+        except Exception as e:
+            print("\tFailed with exception: {}".format(type(e)))
+
+        project = """
+            "kind": "Project"
+            "apiVersion": "project.openshift.io/v1"
+            "metadata":
+                "name": "{}"
+            """.format(self.namespace)
+        project_yaml = yaml.load(project, Loader=yaml.FullLoader)
+
+        try:
+            self.projects_resource.get(name=self.namespace)
+            logging.warning("Namespace {} already exists.".format(
+                self.namespace
+            ))
+        except exceptions.NotFoundError:
+            logging.info("Project {} not found, creating...".format(
+                self.namespace
+            ))
+            self.projects_resource.create(body=project_yaml)
+
+    def oc_process(self, template: dict) -> dict:
+        """
+        Process the given template in OpenShift.
+
+        :returns a processed template
+        """
+        endpoint = "{}/apis/template.openshift.io" \
+                   "/v1/namespaces/{}/processedtemplates".format(
+                    self.openshift_api_url,
+                    self.namespace
+                    )
+        response = requests.post(
+            endpoint,
+            json=template,
+            headers={
+                "Authorization": "Bearer {}".format(self.token),
+                "Content-Type": "application/json",
+            },
+            verify=self.kubernetes_verify_tls,
+        )
+
+        logging.debug(
+            "OpenShift master response template (%d): %r",
+            response.status_code,
+            response.text,
+        )
+
+        try:
+            response.raise_for_status()
+        except Exception:
+            logging.error("Failed to process template: %s", response.text)
+            raise
+
+        return response.json()
+
+    def deploy_template(self, template_yaml: dict) -> list:
+        """
+        Deploy a processed template's objects.
+
+        :param template_yaml: a processed template
+        :return: the list of deployed objects
+        """
+        template = self.oc_process(template_yaml)
+        deployed_objects = []
+        for template_object in template['objects']:
+            response = self.client.resources.get(
+                api_version=template_object["apiVersion"],
+                kind=template_object["kind"]
+            ).create(
+                body=template_object,
+                namespace=self.namespace
+            )
+
+            response = response.to_dict()
+            deployed_objects.append(response)
+            logging.debug("OpenShift response for creating tempate object: %r",
+                          response)
+        return deployed_objects
+
+    @staticmethod
+    def set_template_parameters(template: dict, **parameters: object) -> dict:
+        """
+        Set template parameters.
+
+        Set parameters in the template - replace existing ones or append to
+        parameter list if not exist.
+
+        :returns    template with parameters set/replaced/appended
+        """
+        logging.debug(
+            "Setting parameters for template %r: %s",
+            template["metadata"]["name"],
+            parameters,
+        )
+
+        if "parameters" not in template:
+            template["parameters"] = []
+
+        for parameter_name, parameter_value in parameters.items():
+            for entry in template["parameters"]:
+                if entry["name"] == parameter_name:
+                    entry["value"] = (
+                        str(parameter_value)
+                        if parameter_value is not None
+                        else ""
+                    )
+                    break
+            else:
+                logging.warning(
+                    "Requested to assign parameter %r (value %r) to template "
+                    "but template does not provide the given parameter, "
+                    "forcing...",
+                    parameter_name,
+                    parameter_value,
+                )
+                template["parameters"].append(
+                    {
+                        "name": parameter_name,
+                        "value": str(parameter_value)
+                        if parameter_value is not None
+                        else "",
+                    }
+                )
+        return template
+
+    def remove_objects(self, oc_objects: list):
+        """Remove Openshift."""
+        for obj in oc_objects:
+            api_version, kind = obj['apiVersion'], obj['kind']
+            name = obj['metadata']['name']
+            res = self.client.resources.get(api_version=api_version, kind=kind)
+            try:
+                logging.info("Attempting to delete object {} "
+                             "with name {}".format(kind, name))
+                res.delete(name=name, namespace=self.namespace)
+                logging.info("Deleted resource {} : {}".format(kind, name))
+            except NotFoundError as e:
+                logging.warning("Could not find template {} to delete.".format(
+                    name
+                ))
+
+    def remove_template(self, template: dict):
+        """Remove template from ocp namespace."""
+        api_version, kind = template['apiVersion'], template['kind']
+        name = template['metadata']['name']
+        res = self.client.resources.get(api_version=api_version,
+                                        kind=kind,
+                                        singular_name="template")
+        try:
+            logging.info("Attempting to delete template {} "
+                         "with name {}".format(kind, name))
+            res.delete(name=name, namespace=self.namespace)
+        except NotFoundError as e:
+            logging.warning("Could not find template {} to delete.".format(name))
+
+    @staticmethod
+    def extract_resource_from_response(resp: list, kind: str) -> list:
+        """
+        Take a list of openshift objects and filters on <kind>.
+
+        :returns a list of <kind> objects
+        """
+        resources = []
+        for obj in resp:
+            if obj['kind'] == kind:
+                resources.append(obj)
+        if not resources:
+            logging.error("Resource {} does not exist in the list of "
+                          "objects given".format(kind))
+            raise Exception("Resource does not exist.")
+        return resources
+
+
+def wait_for_condition(success_cond: Callable,
+                       min_to_wait: int,
+                       fail_cond: Callable = None) -> bool:
+    """
+    Wait for condition <bool_fn()> for <min_to_wait> minutes.
+
+    :returns True to indicate success, False otherwise (timeout or failure).
+    """
+    timeout = time.time() + 60 * min_to_wait
+    timedout = False
+    failed = False
+    success = False
+    while not success and not timedout and not failed:
+        if success_cond():
+            success = True
+        elif fail_cond is not None and fail_cond():
+            failed = True
+        elif time.time() > timeout:
+            timedout = True
+        else:
+            time.sleep(1)
+    return success
+
+
+def template_deployer(openshift: OpenShift,
+                      spec: str,
+                      config: dict,
+                      **parameters: object) -> list:
+    """
+    Deploy template.
+
+    Deploy the template_yaml objects on an openshift namespace, if nodeploy is
+    set, then simply return the processed template instead.
+
+    :returns list of processed template objects that are deployed on openshift
+    """
+    template_yaml = load_yaml(config=config, spec=spec)
+
+    if parameters.items():
+        openshift.set_template_parameters(template_yaml, **parameters)
+    deploy = config['spec'][spec]['deploy'].lower() == "true"
+    action_msg = "Nodeploy enabled, Retrieving" if not deploy \
+        else "Deploy enabled, attempting to deploy"
+    logging.info("{} template: {}".format(action_msg,
+                                          template_yaml['metadata']['name']))
+    v1_templates = openshift.client.resources.get(
+        api_version=template_yaml['apiVersion'],
+        kind=template_yaml['kind'],
+        singular_name='template')
+    if not deploy:
+        return openshift.oc_process(template_yaml)['objects']
+    else:
+        try:
+            v1_templates.create(
+                body=template_yaml,
+                namespace=openshift.namespace
+            )
+            resource_objects = openshift.deploy_template(template_yaml)
+        except ConflictError as e:
+            error_msg = "Encountered error when attempting to create template" \
+                        " objects from template {}. Response from ocp: {}"\
+                        .format(template_yaml['metadata']['name'],
+                                e.body,)
+            logging.error(error_msg)
+            return []
+        return resource_objects
+
+
+def delete_template(openshift: OpenShift, config: dict, spec: str):
+    """Delete template."""
+    template_yaml = load_yaml(config=config, spec=spec)
+    openshift.remove_template(template_yaml)
+
+
+def delete_objects(openshift: OpenShift,
+                   config: dict,
+                   spec: str,
+                   **parameters: object):
+    """Delete template."""
+    template_yaml = load_yaml(config=config, spec=spec)
+    if parameters.items():
+        openshift.set_template_parameters(template_yaml, **parameters)
+    processed_template = openshift.oc_process(template_yaml)
+    openshift.remove_objects(processed_template['objects'])
+
+
+def deployment_running(openshift: OpenShift, deploy_cfg: dict,
+                       timeout_amount: int) -> bool:
+    """
+    Check if deployment is running.
+
+    Test if a Deployment in openshift that was configured by the deploy_cfg
+    deployed successfully. Wait timeout_amount minutes for deployment to reach
+    Running phase.
+
+    :returns True if deployment configured by deploy_cfg was successful.
+    """
+    # wait <timeout_amount> minutes for deployment or else time out
+    deployments_started = wait_for_condition(
+        success_cond=lambda: len(
+            openshift.get_pods_by_deployment_cfg(deploy_cfg)
+        ) > 0,
+        min_to_wait=timeout_amount
+    )
+
+    assert deployments_started
+
+    # Wait for pods to reach running state
+    deployment_pods_running = wait_for_condition(
+        success_cond=lambda: openshift.pods_running(
+            pods=openshift.get_pods_by_deployment_cfg(deploy_cfg)
+        ),
+        fail_cond=lambda: openshift.pods_failed(
+            pods=openshift.get_pods_by_deployment_cfg(deploy_cfg)
+        ),
+        min_to_wait=timeout_amount
+    )
+    return deployment_pods_running
+
+
+def container_running(openshift: OpenShift,
+                      deploy_cfg: dict,
+                      timeout_amount: int,
+                      container_id: int,
+                      pod_log_file_prefix: str = None) -> bool:
+    """
+    Check if container is running.
+
+    Test if a container in an openshift pod that was configured by
+    the deploy_cfg is running. Wait timeout_amount minutes for deployment to
+    reach Running state.
+
+    precondition: pod deployment is assumed to have started
+
+    :returns True if container reaches running state in <timeout_amount> min.
+    """
+    # Wait for pods to reach running state
+    deployment_pod_running = wait_for_condition(
+        success_cond=lambda: openshift.containers_are_running(
+            container_id=container_id,
+            pods=openshift.get_pods_by_deployment_cfg(deploy_cfg)
+        ),
+        fail_cond=lambda: openshift.containers_are_failing(
+            container_id=container_id,
+            pods=openshift.get_pods_by_deployment_cfg(deploy_cfg)
+        ),
+        min_to_wait=timeout_amount
+    )
+    pods = openshift.get_pods_by_deployment_cfg(deploy_cfg)
+    for i, pod in enumerate(pods):
+        if pod_log_file_prefix:
+            try:
+                name = pod['metadata']['name']
+                store_logs(filename_prefix=pod_log_file_prefix, name=name,
+                           log_fn=lambda x: openshift.get_pod_log(pod_id=x))
+            except Exception:
+                # Might encounter an error if the build was cancelled
+                logging.error("Could not save pod logs to {}, this maybe due "
+                              "to the pod being unable to "
+                              "start.".format(pod_log_file_prefix))
+
+    return deployment_pod_running
+
+
+def build_finished_successfully(openshift: OpenShift,
+                                build_cfg: dict,
+                                timeout_amount: int,
+                                build_log_file: str = None):
+    """
+    Check if build finished successfully (reached completion).
+
+    Test if a Build in openshift that was configured by the <build_cfg>
+    finished successfully. Wait <timeout_amount> minutes for build to reach
+    Completed phase.
+
+    If <bulid_log_file> is provided, then the build log output is saved
+    to this filepath.
+
+    :returns    True if build configured by <build_cfg> completed.
+                False if build failed, was cancelled, or error'd out.
+    """
+    # Ensure that there are builds that were configured by factstore build_cfg
+    builds_started = wait_for_condition(
+        success_cond=lambda: len(
+            openshift.get_builds_by_buildconfig(build_cfg)
+        ) > 0,
+        min_to_wait=timeout_amount
+    )
+    assert builds_started
+
+    build_sucessfully_completed = wait_for_condition(
+        success_cond=lambda: openshift.is_build_complete(build_cfg),
+        min_to_wait=timeout_amount,
+        fail_cond=lambda: openshift.is_build_failed(build_cfg)
+    )
+
+    if build_log_file:
+        builds = openshift.get_builds_by_buildconfig(build_cfg)
+        for build in builds:
+            try:
+
+                name = build['metadata']['name']
+                store_logs(filename_prefix=build_log_file,
+                           name=name,
+                           log_fn=lambda x: openshift.get_build_log(build_id=x))
+            except Exception:
+                # Might encounter an error if the build was cancelled
+                logging.error("Could not save "
+                              "build logs to {}".format(build_log_file))
+    return build_sucessfully_completed
+
+
+def load_yaml(config: dict, spec: str):
+    """Load and return a dict as yaml file."""
+    path = config['spec'][spec]['template']
+    if path.startswith("http"):
+        with url_request.urlopen(path) as stream:
+            yml = yaml.safe_load(stream)
+    else:
+        with open(path, 'r') as stream:
+            yml = yaml.safe_load(stream)
+    return yml
+
+
+def store_logs(filename_prefix: str, name: str,
+               log_fn: Callable, append: bool = False):
+    """Store logs with the option to append with prefix and name."""
+    logs = log_fn(name)
+    filename = "{}-{}".format(filename_prefix, name)
+    mode = 'a' if append else 'w+'
+    with open(filename, mode) as build_log:
+        build_log.write(logs)
+
+
+def check_skip_test(config: dict, spec: str, test_name: str):
+    """Skip tests for a spec if indicated in the pytest yaml config."""
+    if config['spec'][spec]['runtests'].lower() == "false":
+        pytest.skip("Test: {}.".format(test_name))


### PR DESCRIPTION
This PR introduces openshift integration tests to LAD. 
The PR also introduces a YAML-version of the MySQL-persistent json template (more consistency since the rest of the templates are also yaml) - this makes the testing logic more consistent as well. 
Currently the tests will test: 
 - Successful builds
 - Route health for factstore/ad_demo and db connectivity between mysql/factstore
 - Successful deployments 
 - Success on container starts
There are currently no tests that actually test a successful or failed anomaly detection atm. 

You can use the Makefile to run these tests, the make file will create the appropriate config file and run the tests based off those configuration: 
```
Usage: 
# This command will create a config yaml and pass it to pytest, 
# this will deploy the entire LAD stack and run tests against this deployment. 

$ cd tests/e2e
$ make e2e-tests-run host=<ocp host> auth=<ocp auth token> namespace=<ocp namespace> 

# Once done, you can call make clean to delete everything deployed by the tests: 

$ make e2e-tests-clean host=<ocp host> auth=<ocp auth token> namespace=<ocp namespace> 
```
If you want a bit more control over what aspects of the stack you want to test you can make your own config file and run the following command to run the tests: 
```
pytest test_openshift_deployments.py --pytest_config=<your config>.yaml
```

The `config.yaml` offers configuration options for the integration testing. Ensure that the `pytest_config` is appropriately filled out with information about your ocp host. The example `config.yaml` that's provided includes all currently available options with some additional comments for further clarifications. 