### PR TITLE
Adjust custom rules for Storage Proxy so you can not pass .source or .sink

### DIFF
--- a/anomaly_detector/config.py
+++ b/anomaly_detector/config.py
@@ -44,8 +44,8 @@ class Configuration(Borg):
     FACT_STORE_URL = ""
     FREQ_NOISE = 1
     # One of the storage backends available in storage/ dir
-    STORAGE_DATASOURCE = "local.source"
-    STORAGE_DATASINK = "local.sink"
+    STORAGE_DATASOURCE = "local"
+    STORAGE_DATASINK = "local"
     # Location of local data
     # A directory where trained models will be stored
     MODEL_DIR = "./models/"

--- a/anomaly_detector/storage/storage_catalog.py
+++ b/anomaly_detector/storage/storage_catalog.py
@@ -8,7 +8,7 @@ import logging
 
 
 class StorageCatalog(object):
-    """Storage Catalog for storing data to and from ML Runs."""
+    """Internal api and client should use storage proxy for data access.."""
 
     def __init__(self, config, storage_api):
         """Storage initialization logic."""

--- a/anomaly_detector/storage/storage_proxy.py
+++ b/anomaly_detector/storage/storage_proxy.py
@@ -8,10 +8,15 @@ from anomaly_detector.storage.storage_sink import StorageSink
 class StorageProxy(StorageSource, StorageSink):
     """Storage Proxy for facilitating communication with backend."""
 
+    SUFFIX_SOURCE = ".source"
+    SUFFIX_SINK = ".sink"
+
     def __init__(self, config: Configuration):
         """Create storage data source and sinks to talk to storage backend."""
-        self.source = StorageCatalog(config=config, storage_api=config.STORAGE_DATASOURCE).get_storage_api()
-        self.sink = StorageCatalog(config=config, storage_api=config.STORAGE_DATASINK).get_storage_api()
+        self.source = StorageCatalog(config=config,
+                                     storage_api=config.STORAGE_DATASOURCE + self.SUFFIX_SOURCE).get_storage_api()
+        self.sink = StorageCatalog(config=config,
+                                   storage_api=config.STORAGE_DATASINK + self.SUFFIX_SINK).get_storage_api()
 
     def retrieve(self, storage_attribute):
         """Retrieve data from backend storage."""

--- a/docs/source/storage.rst
+++ b/docs/source/storage.rst
@@ -1,7 +1,44 @@
 Storage
 =======
 
-There are 2 storage backends implemented at the moment - ElasticSearch and local.
+The following table provides source and sink configuration fields that you can set for your data pipeline
+
++-----------------+----------+--------+
+| Data Source     | Source   | Sink   |
++=================+==========+========+
+| Elasticsearch   | es       | es     |
++-----------------+----------+--------+
+| Local           | local    | local  |
++-----------------+----------+--------+
+| Local Directory | localdir |        |
++-----------------+----------+--------+
+| Console Output  |          | stdout |
++-----------------+----------+--------+
+| Kafka           |          | kafka  |
++-----------------+----------+--------+
+
+
+
+Example
+-------
+To read from Elasticsearch and write predictions to Kafka you can use the following configurations
+
+.. code-block:: shell
+
+   STORAGE_DATASOURCE: “es”
+   STORAGE_DATASINK: “kafka”
+
+.. image:: ../../imgs/storage-example.png
+
+.. DANGER::
+
+   We have removed es.source/es.sink entirely and you need to specify "es" instead. See table above.
+
+
+
+Storage Details
+===============
+
 
 ElasticSearch
 -------------
@@ -20,7 +57,7 @@ Input data can be in a form of JSON (one entry per line) or plain text (simplifi
 
 
 Stdout
------
+------
 
 You can output anomalies found out on console to allow us to debug without sending emails.
 
@@ -29,17 +66,8 @@ LocalDir
 --------
 This works the same as the local storage except this will let you read from a directory of logs which can either be json or common log. We support only files ending with '.log' or '.json'
 
-Example
--------
-To read from Elasticsearch and write predictions to Kafka you can use the following configurations
-
-.. code-block:: shell
-
-   STORAGE_DATASOURCE: “es.source”
-   STORAGE_DATASINK: “kafka.sink”
 
 
-.. image:: ../../imgs/storage-example.png
 
 
 
@@ -64,9 +92,6 @@ See: https://github.com/AICoE/log-anomaly-detector/issues/281 for example of how
 See: https://github.com/AICoE/log-anomaly-detector/issues/207 for example of how to add new storage source
 
 
-Note you will need to update the storage_catalog.py which can be found here:
-
-.. literalinclude:: ../../anomaly_detector/storage/storage_catalog.py
 
  
 

--- a/tests/test_false_anomaly_check.py
+++ b/tests/test_false_anomaly_check.py
@@ -13,7 +13,10 @@ LOG_MSG = "(root) CMD (/usr/local/bin/monitor-apache-stats.sh >/dev/null 2>&1)"
 @pytest.fixture()
 def config():
     """Provide default configurations to load yaml instead of env var."""
-    config = Configuration(config_yaml="config_files/.test_env_config.yaml")
+    config = Configuration()
+    config.STORAGE_DATASOURCE = "local"
+    config.STORAGE_DATASINK = "stdout"
+    config.LS_INPUT_PATH = "validation_data/log_anomaly_detector-100000-events.json"
     return config
 
 

--- a/tests/test_som.py
+++ b/tests/test_som.py
@@ -15,8 +15,10 @@ CONFIGURATION_PREFIX = "LAD"
 @pytest.fixture()
 def config():
     """Initialize configurations before testing."""
-    config = Configuration(prefix=CONFIGURATION_PREFIX, config_yaml="config_files/.env_config.yaml")
-
+    config = Configuration()
+    config.STORAGE_DATASOURCE = "local"
+    config.STORAGE_DATASINK = "stdout"
+    config.LS_INPUT_PATH = "validation_data/Hadoop_2k.json"
     return config
 
 

--- a/tests/test_storage_catalog.py
+++ b/tests/test_storage_catalog.py
@@ -16,7 +16,8 @@ NUM_LOG_LINES = 812
 def config():
     """Initialize configurations before testing."""
     config = Configuration()
-    config.STORAGE_BACKEND = "local"
+    config.STORAGE_DATASOURCE = "local"
+    config.STORAGE_DATASINK = "local"
     config.LS_INPUT_PATH = "validation_data/orders-500.log"
     config.LS_OUTPUT_PATH = "validation_data/results-oct4.1.txt"
     return config

--- a/tests/test_storage_proxy.py
+++ b/tests/test_storage_proxy.py
@@ -1,0 +1,23 @@
+"""Test storage proxy to validate if api rules are enforced."""
+import pytest
+
+from anomaly_detector.config import Configuration
+from anomaly_detector.storage.storage_proxy import StorageProxy
+
+
+@pytest.fixture()
+def config():
+    """Initialize configurations before testing."""
+    config = Configuration()
+    config.STORAGE_DATASOURC = "local.source"
+    config.STORAGE_DATASINK = "local.sink"
+    config.LS_INPUT_PATH = "validation_data/orders-500.log"
+    config.LS_OUTPUT_PATH = "validation_data/results-oct4.1.txt"
+    return config
+
+
+def test_storage_proxy_throws_exception(config):
+    """Test that if there is an invalid usage of api that we throw exception."""
+    with pytest.raises(ValueError) as excinfo:
+        StorageProxy(config=config)
+    assert excinfo.type == ValueError

--- a/tests/test_task_manager.py
+++ b/tests/test_task_manager.py
@@ -3,7 +3,7 @@ from unittest import TestCase
 from anomaly_detector.adapters.som_model_adapter import SomModelAdapter
 from anomaly_detector.adapters.som_storage_adapter import SomStorageAdapter
 from anomaly_detector.config import Configuration
-from anomaly_detector.jobs import *
+from anomaly_detector.jobs.core import Pipeline, SomTrainJob, AbstractCommand
 
 TASKS_IN_QUEUE = 1
 
@@ -14,7 +14,10 @@ class TestTaskManager(TestCase):
     def test_train_command(self):
         """Test case for validating that when we train a model and add it to task queue that it will run."""
         mgr = Pipeline()
-        config = Configuration(config_yaml="config_files/.env_config.yaml")
+        config = Configuration()
+        config.STORAGE_DATASOURCE = "local"
+        config.STORAGE_DATASINK = "stdout"
+        config.LS_INPUT_PATH = "validation_data/Hadoop_2k.json"
         storage_adapter = SomStorageAdapter(config=config, feedback_strategy=None)
         model_adapter = SomModelAdapter(storage_adapter)
         tc = SomTrainJob(node_map=2, model_adapter=model_adapter)

--- a/tests/test_valid_storage.py
+++ b/tests/test_valid_storage.py
@@ -6,14 +6,16 @@ from anomaly_detector.config import Configuration
 from anomaly_detector.jobs import SomTrainJob, SomInferenceJob
 from anomaly_detector.storage.local_storage import DefaultStorageAttribute
 
-CONFIGURATION_PREFIX = "LAD"
 NUM_LOG_LINES = 812
 
 
 @pytest.fixture()
 def config():
     """Initialize configurations before testing."""
-    config = Configuration(prefix=CONFIGURATION_PREFIX, config_yaml="config_files/.env_local_dir.yaml")
+    config = Configuration()
+    config.STORAGE_DATASOURCE = "localdir"
+    config.STORAGE_DATASINK = "stdout"
+    config.LS_INPUT_PATH = "validation_data/test_sample_input"
     return config
 
 

--- a/tests/test_validation_data.py
+++ b/tests/test_validation_data.py
@@ -10,7 +10,10 @@ CONFIGURATION_PREFIX = "LAD"
 @pytest.fixture()
 def config():
     """Initialize configurations before testing."""
-    config = Configuration(prefix=CONFIGURATION_PREFIX, config_yaml="config_files/.env_config.yaml")
+    config = Configuration()
+    config.STORAGE_DATASOURCE = "local"
+    config.STORAGE_DATASINK = "stdout"
+    config.LS_INPUT_PATH = "validation_data/Hadoop_2k.json"
     return config
 
 

--- a/tests/test_w2v.py
+++ b/tests/test_w2v.py
@@ -12,8 +12,15 @@ CONFIGURATION_PREFIX = "LAD"
 @pytest.fixture()
 def config():
     """Initialize configurations before testing."""
-    config = Configuration(prefix=CONFIGURATION_PREFIX, config_yaml="config_files/.env_config.yaml")
-
+    config = Configuration()
+    config.STORAGE_DATASOURCE = "local"
+    config.STORAGE_DATASINK = "stdout"
+    config.LS_INPUT_PATH = "validation_data/Hadoop_2k.json"
+    config.W2V_MIN_COUNT = 1
+    config.W2V_ITER = 500
+    config.W2V_COMPUTE_LOSS = "True"
+    config.W2V_SEED = 50
+    config.W2V_WORKERS = 1
     return config
 
 


### PR DESCRIPTION
# Description
Make sure that api users can not just pass es.source or es.sink. But rather use "es" for the source or sink.