### PR TITLE
Add ability to track namespace where prediction originated.

### DIFF
--- a/anomaly_detector/adapters/som_model_adapter.py
+++ b/anomaly_detector/adapters/som_model_adapter.py
@@ -109,6 +109,7 @@ class SomModelAdapter(BaseModelAdapter):
             s["anomaly_score"] = dist[i]
             s["elast_alert"] = self.storage_adapter.ES_ELAST_ALERT
             s["inference_batch_id"] = inference_batch_id
+            s["predictor_namespace"] = self.storage_adapter.OS_NAMESPACE
             s["e_message"] = quote(s["message"])
             # Record anomaly event in fact_store
             if dist[i] > threshold:
@@ -119,7 +120,6 @@ class SomModelAdapter(BaseModelAdapter):
                         continue
                 hist_count += 1
                 s["anomaly"] = 1
-
                 logging.warning("Anomaly found (score: %f): %s" % (dist[i], s["message"]))
                 last_id[quote(s["message"])] = s["predict_id"]
                 ANOMALY_SCORE.set(dist[i])

--- a/anomaly_detector/config.py
+++ b/anomaly_detector/config.py
@@ -129,7 +129,7 @@ class Configuration(Borg):
     KF_SECURITY_PROTOCOL = 'PLAINTEXT'
     KF_AUTO_TIMEOUT = 30000
     ES_ELAST_ALERT = 1
-
+    OS_NAMESPACE = os.getenv("OPENSHIFT_BUILD_NAMESPACE", "localhost")
     prefix = "LAD"
 
     def __init__(self, prefix=None, config_yaml=None):


### PR DESCRIPTION

# Description

When you want to track the which namespace produce what prediction.

# Problem

When we produce predictions we need to track metadata about where it came from. By default it will be set in openshift. 
